### PR TITLE
feat(cab): Make CAB images customizable

### DIFF
--- a/packages/@divvi/mobile/src/keylessBackup/SignInWithEmail.tsx
+++ b/packages/@divvi/mobile/src/keylessBackup/SignInWithEmail.tsx
@@ -113,7 +113,7 @@ function SignInWithEmail({ route, navigation }: Props) {
   }
   const address = useSelector(walletAddressSelector)
 
-  const cloudBackupConfig = getAppConfig()?.assets?.cloudBackup
+  const cloudBackupConfig = getAppConfig().themes?.default?.assets?.cloudBackup
   const emailImage = cloudBackupConfig?.emailImage ? cloudBackupConfig.emailImage : email
 
   // We check whether or not there is anything to go back to

--- a/packages/@divvi/mobile/src/keylessBackup/SignInWithEmail.tsx
+++ b/packages/@divvi/mobile/src/keylessBackup/SignInWithEmail.tsx
@@ -33,6 +33,7 @@ import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
+import { getAppConfig } from 'src/appConfig'
 
 const TAG = 'keylessBackup/SignInWithEmail'
 
@@ -111,6 +112,9 @@ function SignInWithEmail({ route, navigation }: Props) {
     paddingBottom: Math.max(0, 40 - bottom),
   }
   const address = useSelector(walletAddressSelector)
+
+  const cloudBackupConfig = getAppConfig()?.assets?.cloudBackup
+  const emailImage = cloudBackupConfig?.emailImage ? cloudBackupConfig.emailImage : email
 
   // We check whether or not there is anything to go back to
   // in case that this screen is the app's initial route, which can occur
@@ -228,7 +232,7 @@ function SignInWithEmail({ route, navigation }: Props) {
       />
       <ScrollView style={styles.scrollContainer}>
         <View style={styles.imageContainer}>
-          <Image testID="Email" source={email} />
+          <Image testID="Email" source={emailImage} />
         </View>
         <Text style={styles.title}>{t('signInWithEmail.title')}</Text>
         <Text style={styles.subtitle}>

--- a/packages/@divvi/mobile/src/keylessBackup/WalletSecurityPrimer.tsx
+++ b/packages/@divvi/mobile/src/keylessBackup/WalletSecurityPrimer.tsx
@@ -19,7 +19,7 @@ type Props = NativeStackScreenProps<StackParamList, Screens.WalletSecurityPrimer
 
 function WalletSecurityPrimer({ route }: Props) {
   const { t } = useTranslation()
-  const cloudBackupConfig = getAppConfig()?.assets?.cloudBackup
+  const cloudBackupConfig = getAppConfig().themes?.default?.assets?.cloudBackup
   const educationImage = cloudBackupConfig?.educationImage
     ? cloudBackupConfig.educationImage
     : walletSafe

--- a/packages/@divvi/mobile/src/keylessBackup/WalletSecurityPrimer.tsx
+++ b/packages/@divvi/mobile/src/keylessBackup/WalletSecurityPrimer.tsx
@@ -13,16 +13,22 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import { getAppConfig } from 'src/appConfig'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.WalletSecurityPrimer>
 
 function WalletSecurityPrimer({ route }: Props) {
   const { t } = useTranslation()
+  const cloudBackupConfig = getAppConfig()?.assets?.cloudBackup
+  const educationImage = cloudBackupConfig?.educationImage
+    ? cloudBackupConfig.educationImage
+    : walletSafe
+
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
       <ScrollView style={styles.scrollContainer}>
         <View style={styles.imageContainer}>
-          <Image testID="Email" source={walletSafe} />
+          <Image testID="EducationImage" source={educationImage} />
         </View>
         <Text style={styles.title}>{t('walletSecurityPrimer.title')}</Text>
         <Text style={styles.description}>{t('walletSecurityPrimer.description')}</Text>

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -113,6 +113,10 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
           touchId?: ImageSourcePropType
           iris?: ImageSourcePropType
         }
+        cloudBackup?: {
+          educationImage?: ImageSourcePropType
+          emailImage?: ImageSourcePropType
+        }
       }
     }
   }


### PR DESCRIPTION
### Description

Makes branded images used in CAB flow customizable.

### Test plan

Manually tested

### Backwards compatibility

Yes.

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
