### PR TITLE
docs: fix broken links and generation tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Visit our [Getting Started Guide](docs/getting-started.md) for detailed instruct
 - [Getting Started](docs/getting-started.md) - Create your first app
 - [Configuration](docs/configuration.md) - Customize your app
 - [Architecture](docs/architecture.md) - Understand the framework
-- [API Reference](docs/api-reference.md) - Explore the API
+- [API Reference](docs/reference) - Explore the API
 
 ## Example App
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,7 +249,7 @@ const App = createApp({
 
 ## Configuration Reference
 
-For a complete list of configuration options, see the [API reference](api-reference.md) or check the type definition:
+For a complete list of configuration options, see the [API reference](reference) or check the type definition:
 
 ```typescript
 import type { PublicAppConfig } from '@divvi/mobile'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,7 @@ This will build your app and launch it in your simulator/emulator. The developme
 
 - Learn how to [configure your app](configuration.md)
 - Explore the [architecture](architecture.md)
-- Browse the [API reference](api-reference.md)
+- Browse the [API reference](reference)
 
 ## Need Help?
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -8,21 +8,6 @@ title: API reference
 
 This section contains the auto-generated API documentation for the Divvi Mobile framework's public interface.
 
-## Interfaces
-
-- [PreparedTransactionsNeedDecreaseSpendAmountForGas](interfaces/PreparedTransactionsNeedDecreaseSpendAmountForGas.md)
-- [PreparedTransactionsNotEnoughBalanceForGas](interfaces/PreparedTransactionsNotEnoughBalanceForGas.md)
-- [PreparedTransactionsPossible](interfaces/PreparedTransactionsPossible.md)
-- [PublicAppConfig](interfaces/PublicAppConfig.md)
-
-## Type Aliases
-
-- [NetworkId](type-aliases/NetworkId.md)
-- [PreparedTransactionsResult](type-aliases/PreparedTransactionsResult.md)
-- [StackParamList](type-aliases/StackParamList.md)
-- [TransactionRequest](type-aliases/TransactionRequest.md)
-- [UnlockResult](type-aliases/UnlockResult.md)
-
 ## Functions
 
 - [createApp](functions/createApp.md)
@@ -38,3 +23,18 @@ This section contains the auto-generated API documentation for the Divvi Mobile 
 - [useSendTransactions](functions/useSendTransactions.md)
 - [useWallet](functions/useWallet.md)
 - [useWalletClient](functions/useWalletClient.md)
+
+## Interfaces
+
+- [PreparedTransactionsNeedDecreaseSpendAmountForGas](interfaces/PreparedTransactionsNeedDecreaseSpendAmountForGas.md)
+- [PreparedTransactionsNotEnoughBalanceForGas](interfaces/PreparedTransactionsNotEnoughBalanceForGas.md)
+- [PreparedTransactionsPossible](interfaces/PreparedTransactionsPossible.md)
+- [PublicAppConfig](interfaces/PublicAppConfig.md)
+
+## Type Aliases
+
+- [NetworkId](type-aliases/NetworkId.md)
+- [PreparedTransactionsResult](type-aliases/PreparedTransactionsResult.md)
+- [StackParamList](type-aliases/StackParamList.md)
+- [TransactionRequest](type-aliases/TransactionRequest.md)
+- [UnlockResult](type-aliases/UnlockResult.md)

--- a/docs/reference/functions/createApp.md
+++ b/docs/reference/functions/createApp.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / createApp
+[@divvi/mobile](../README.md) / createApp
 
 # Function: createApp()
 

--- a/docs/reference/functions/getFees.md
+++ b/docs/reference/functions/getFees.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / getFees
+[@divvi/mobile](../README.md) / getFees
 
 # Function: getFees()
 

--- a/docs/reference/functions/getPublicClient.md
+++ b/docs/reference/functions/getPublicClient.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / getPublicClient
+[@divvi/mobile](../README.md) / getPublicClient
 
 # Function: getPublicClient()
 

--- a/docs/reference/functions/getWalletClient.md
+++ b/docs/reference/functions/getWalletClient.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / getWalletClient
+[@divvi/mobile](../README.md) / getWalletClient
 
 # Function: getWalletClient()
 

--- a/docs/reference/functions/navigate.md
+++ b/docs/reference/functions/navigate.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / navigate
+[@divvi/mobile](../README.md) / navigate
 
 # Function: navigate()
 

--- a/docs/reference/functions/prepareTransactions.md
+++ b/docs/reference/functions/prepareTransactions.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / prepareTransactions
+[@divvi/mobile](../README.md) / prepareTransactions
 
 # Function: prepareTransactions()
 

--- a/docs/reference/functions/sendTransactions.md
+++ b/docs/reference/functions/sendTransactions.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / sendTransactions
+[@divvi/mobile](../README.md) / sendTransactions
 
 # Function: sendTransactions()
 

--- a/docs/reference/functions/unlockAccount.md
+++ b/docs/reference/functions/unlockAccount.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / unlockAccount
+[@divvi/mobile](../README.md) / unlockAccount
 
 # Function: unlockAccount()
 

--- a/docs/reference/functions/usePrepareTransactions.md
+++ b/docs/reference/functions/usePrepareTransactions.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / usePrepareTransactions
+[@divvi/mobile](../README.md) / usePrepareTransactions
 
 # Function: usePrepareTransactions()
 

--- a/docs/reference/functions/usePublicClient.md
+++ b/docs/reference/functions/usePublicClient.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / usePublicClient
+[@divvi/mobile](../README.md) / usePublicClient
 
 # Function: usePublicClient()
 

--- a/docs/reference/functions/useSendTransactions.md
+++ b/docs/reference/functions/useSendTransactions.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / useSendTransactions
+[@divvi/mobile](../README.md) / useSendTransactions
 
 # Function: useSendTransactions()
 

--- a/docs/reference/functions/useWallet.md
+++ b/docs/reference/functions/useWallet.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / useWallet
+[@divvi/mobile](../README.md) / useWallet
 
 # Function: useWallet()
 

--- a/docs/reference/functions/useWalletClient.md
+++ b/docs/reference/functions/useWalletClient.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / useWalletClient
+[@divvi/mobile](../README.md) / useWalletClient
 
 # Function: useWalletClient()
 

--- a/docs/reference/interfaces/PreparedTransactionsNeedDecreaseSpendAmountForGas.md
+++ b/docs/reference/interfaces/PreparedTransactionsNeedDecreaseSpendAmountForGas.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / PreparedTransactionsNeedDecreaseSpendAmountForGas
+[@divvi/mobile](../README.md) / PreparedTransactionsNeedDecreaseSpendAmountForGas
 
 # Interface: PreparedTransactionsNeedDecreaseSpendAmountForGas
 

--- a/docs/reference/interfaces/PreparedTransactionsNotEnoughBalanceForGas.md
+++ b/docs/reference/interfaces/PreparedTransactionsNotEnoughBalanceForGas.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / PreparedTransactionsNotEnoughBalanceForGas
+[@divvi/mobile](../README.md) / PreparedTransactionsNotEnoughBalanceForGas
 
 # Interface: PreparedTransactionsNotEnoughBalanceForGas
 

--- a/docs/reference/interfaces/PreparedTransactionsPossible.md
+++ b/docs/reference/interfaces/PreparedTransactionsPossible.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / PreparedTransactionsPossible
+[@divvi/mobile](../README.md) / PreparedTransactionsPossible
 
 # Interface: PreparedTransactionsPossible
 

--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / PublicAppConfig
+[@divvi/mobile](../README.md) / PublicAppConfig
 
 # Interface: PublicAppConfig\<tabScreenConfigs\>
 

--- a/docs/reference/type-aliases/NetworkId.md
+++ b/docs/reference/type-aliases/NetworkId.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / NetworkId
+[@divvi/mobile](../README.md) / NetworkId
 
 # Type Alias: NetworkId
 

--- a/docs/reference/type-aliases/PreparedTransactionsResult.md
+++ b/docs/reference/type-aliases/PreparedTransactionsResult.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / PreparedTransactionsResult
+[@divvi/mobile](../README.md) / PreparedTransactionsResult
 
 # Type Alias: PreparedTransactionsResult
 

--- a/docs/reference/type-aliases/StackParamList.md
+++ b/docs/reference/type-aliases/StackParamList.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / StackParamList
+[@divvi/mobile](../README.md) / StackParamList
 
 # Type Alias: StackParamList
 

--- a/docs/reference/type-aliases/TransactionRequest.md
+++ b/docs/reference/type-aliases/TransactionRequest.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / TransactionRequest
+[@divvi/mobile](../README.md) / TransactionRequest
 
 # Type Alias: TransactionRequest
 

--- a/docs/reference/type-aliases/UnlockResult.md
+++ b/docs/reference/type-aliases/UnlockResult.md
@@ -1,8 +1,8 @@
-[**@divvi/mobile**](../index.md)
+[**@divvi/mobile**](../README.md)
 
 ---
 
-[@divvi/mobile](../index.md) / UnlockResult
+[@divvi/mobile](../README.md) / UnlockResult
 
 # Type Alias: UnlockResult
 

--- a/packages/@divvi/mobile/typedoc.json
+++ b/packages/@divvi/mobile/typedoc.json
@@ -2,6 +2,7 @@
   // See the following for more details:
   // - https://typedoc-plugin-markdown.org/docs/options
   // - https://typedoc-plugin-markdown.org/plugins/frontmatter/options
+  "$schema": "https://typedoc-plugin-markdown.org/schema.json",
   "exclude": ["**/*+(index|.test).ts"],
   "excludePrivate": true,
   "excludeInternal": true,
@@ -18,10 +19,11 @@
   "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter"],
   // Append the documentation index page to the readme page.
   "mergeReadme": true,
-  "entryFileName": "index",
-  "indexFrontmatter": {
+  "readmeFrontmatter": {
     "title": "API reference"
   },
   "formatWithPrettier": true,
-  "useCodeBlocks": true
+  "useCodeBlocks": true,
+  // Show functions first in the index
+  "groupOrder": ["Functions", "*"]
 }


### PR DESCRIPTION
### Description

The docs repo failed to pull the latest changes as they don't build:
```
  Exhaustive list of all broken links found:
  - Broken link on source page path = /mobile-framework/divvi-mobile/configuration:
     -> linking to api-reference.md (resolved as: /mobile-framework/divvi-mobile/api-reference.md)
  - Broken link on source page path = /mobile-framework/divvi-mobile/getting-started:
     -> linking to api-reference.md (resolved as: /mobile-framework/divvi-mobile/api-reference.md)
```

Also tweaked the config so functions are displayed first in the generated index.
And using `README.md` instead of `index.md` so it also works when viewing from GitHub.