### PR TITLE
fix: failing npm publish due to using outdated tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           # Full git history is needed for release notes
           fetch-depth: 0
+      - name: Debug Git Tags
+        run: git tag -l | sort -V
+      - name: Fetch all tags
+        run: git fetch --tags --force
       - id: auth
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
### Description

The release jobs started failing a few days ago. An example failure is [here](https://github.com/divvi-xyz/divvi-mobile/actions/runs/13638145091/job/38121732763) - all the failed runs seem to fail with the same error about the `alpha.32` tag already existing.

My understanding is that the release job should look for the latest tag, and create a new release based on the data in the tag. The release jobs seem to be picking `alpha.31` as the latest tag, even though that is not the case in git or npm (`alpha.32` is definitely published, so i don't think it's safe to simply delete the tag and try again).

`actions/checkout@v4` with `fetch-depth: 0` _should_ already fetch the latest tags, so I'm not really sure what's going wrong. This PR adds some additional logging and an extra step to fetch tags, in case it helps.

### Test plan

Sadly can't test this until it's in the main branch

