### PR TITLE
feat: add InfoBottomSheet

### DIFF
--- a/packages/@divvi/mobile/src/components/InfoBottomSheet.test.tsx
+++ b/packages/@divvi/mobile/src/components/InfoBottomSheet.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import lodash from 'lodash'
+import React from 'react'
+import { Provider } from 'react-redux'
+import InfoBottomSheet from 'src/components/InfoBottomSheet'
+import { createMockStore } from 'test/utils'
+
+describe('InfoBottomSheet', () => {
+  it('renders the structure properly', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <InfoBottomSheet
+          forwardedRef={{ current: null }}
+          title="Info Bottom Sheet Title"
+          testID="TestInfoBottomSheet"
+        >
+          Info Bottom Sheet Content
+        </InfoBottomSheet>
+      </Provider>
+    )
+
+    expect(getByTestId('TestInfoBottomSheet')).toHaveTextContent('Info Bottom Sheet Title')
+    expect(getByTestId('TestInfoBottomSheet/Content')).toHaveTextContent(
+      'Info Bottom Sheet Content'
+    )
+    expect(getByTestId('TestInfoBottomSheet/DismissButton')).toHaveTextContent(
+      'bottomSheetDismissButton'
+    )
+  })
+
+  it('properly executes dismiss action when dismiss button is pressed', async () => {
+    const mockClose = jest.fn() as any
+    // this is necessary to eliminate hurdles with the onPress implementation of the Button component
+    jest.spyOn(lodash, 'debounce').mockReturnValue(mockClose)
+
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <InfoBottomSheet
+          forwardedRef={{ current: { close: mockClose } as any }}
+          title="Info Bottom Sheet Title"
+          testID="TestInfoBottomSheet"
+        >
+          Info Bottom Sheet Content
+        </InfoBottomSheet>
+      </Provider>
+    )
+
+    fireEvent.press(getByTestId('TestInfoBottomSheet/DismissButton'))
+    expect(mockClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/@divvi/mobile/src/components/InfoBottomSheet.tsx
+++ b/packages/@divvi/mobile/src/components/InfoBottomSheet.tsx
@@ -16,12 +16,15 @@ export default function InfoBottomSheet(props: {
 
   return (
     <BottomSheet forwardedRef={props.forwardedRef} title={props.title} testId={props.testID}>
-      <View style={styles.content}>{props.children}</View>
+      <View style={styles.content} testID={`${props.testID}/Content`}>
+        {props.children}
+      </View>
       <Button
         type={BtnTypes.SECONDARY}
         size={BtnSizes.FULL}
         text={t('bottomSheetDismissButton')}
         onPress={() => props.forwardedRef.current?.close()}
+        testID={`${props.testID}/DismissButton`}
       />
     </BottomSheet>
   )

--- a/packages/@divvi/mobile/src/components/InfoBottomSheet.tsx
+++ b/packages/@divvi/mobile/src/components/InfoBottomSheet.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, View } from 'react-native'
+import type { BottomSheetModalRefType } from 'src/components/BottomSheet'
+import BottomSheet from 'src/components/BottomSheet'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { Spacing } from 'src/styles/styles'
+
+export default function InfoBottomSheet(props: {
+  forwardedRef: React.RefObject<BottomSheetModalRefType>
+  title: string
+  children: React.ReactNode
+  testID?: string
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <BottomSheet forwardedRef={props.forwardedRef} title={props.title} testId={props.testID}>
+      <View style={styles.content}>{props.children}</View>
+      <Button
+        type={BtnTypes.SECONDARY}
+        size={BtnSizes.FULL}
+        text={t('bottomSheetDismissButton')}
+        onPress={() => props.forwardedRef.current?.close()}
+      />
+    </BottomSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  content: {
+    gap: Spacing.Smallest8,
+    marginBottom: Spacing.Thick24,
+  },
+})

--- a/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
+++ b/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
@@ -1,12 +1,9 @@
-import type { BottomSheetModal } from '@gorhom/bottom-sheet'
 import BigNumber from 'bignumber.js'
 import React, { useMemo, type ReactNode } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View, type StyleProp, type TextStyle } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import BackButton from 'src/components/BackButton'
-import BottomSheet from 'src/components/BottomSheet'
-import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import ContactCircle from 'src/components/ContactCircle'
 import CustomHeader from 'src/components/header/CustomHeader'
 import SkeletonPlaceholder from 'src/components/SkeletonPlaceholder'
@@ -369,25 +366,6 @@ export function ReviewDetailsItemTotalValue({
   })
 }
 
-export function ReviewTotalBottomSheet(props: {
-  forwardedRef: React.RefObject<BottomSheetModal>
-  title: string
-  children: React.ReactNode
-}) {
-  const { t } = useTranslation()
-  return (
-    <BottomSheet forwardedRef={props.forwardedRef} testId="InfoBottomSheet" title={props.title}>
-      <View style={styles.totalBottomSheetContent}>{props.children}</View>
-      <Button
-        type={BtnTypes.SECONDARY}
-        size={BtnSizes.FULL}
-        text={t('bottomSheetDismissButton')}
-        onPress={() => props.forwardedRef.current?.close()}
-      />
-    </BottomSheet>
-  )
-}
-
 const styles = StyleSheet.create({
   safeAreaView: {
     flex: 1,
@@ -470,9 +448,5 @@ const styles = StyleSheet.create({
   },
   totalPlusFeesLocalAmount: {
     color: colors.contentSecondary,
-  },
-  totalBottomSheetContent: {
-    gap: Spacing.Smallest8,
-    marginBottom: Spacing.Thick24,
   },
 })

--- a/packages/@divvi/mobile/src/send/SendConfirmation.tsx
+++ b/packages/@divvi/mobile/src/send/SendConfirmation.tsx
@@ -9,6 +9,7 @@ import { ErrorMessages } from 'src/app/ErrorMessages'
 import BackButton from 'src/components/BackButton'
 import type { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes } from 'src/components/Button'
+import InfoBottomSheet from 'src/components/InfoBottomSheet'
 import {
   ReviewContent,
   ReviewDetails,
@@ -17,7 +18,6 @@ import {
   ReviewSummary,
   ReviewSummaryItem,
   ReviewSummaryItemContact,
-  ReviewTotalBottomSheet,
   ReviewTransaction,
 } from 'src/components/ReviewTransaction'
 import { formatValueToDisplay } from 'src/components/TokenDisplay'
@@ -220,7 +220,7 @@ export default function SendConfirmation(props: Props) {
         />
       </ReviewFooter>
 
-      <ReviewTotalBottomSheet forwardedRef={feesBottomSheetRef} title={t('networkFee')}>
+      <InfoBottomSheet forwardedRef={feesBottomSheetRef} title={t('networkFee')}>
         <ReviewDetailsItem
           approx
           fontSize="small"
@@ -241,9 +241,9 @@ export default function SendConfirmation(props: Props) {
           tokenInfo={feeTokenInfo}
           localCurrencySymbol={localCurrencySymbol}
         />
-      </ReviewTotalBottomSheet>
+      </InfoBottomSheet>
 
-      <ReviewTotalBottomSheet
+      <InfoBottomSheet
         forwardedRef={totalBottomSheetRef}
         title={t('reviewTransaction.totalPlusFees')}
       >
@@ -281,7 +281,7 @@ export default function SendConfirmation(props: Props) {
           feeLocalAmount={localMaxFeeAmount}
           localCurrencySymbol={localCurrencySymbol}
         />
-      </ReviewTotalBottomSheet>
+      </InfoBottomSheet>
     </ReviewTransaction>
   )
 }


### PR DESCRIPTION
### Description
As per the title. I need this as a part of my work on refactoring Earn deposit confirmation flow to use new review screen. Moved this out of ReviewTransaction component as it is gonna be used for all info sheets on send/earn/swap. This is a very simple abstraction with button always sticking to the bottom and content being separated with spacing away from it.

### Test plan
No tests needed, this is a really simple component the only testing of which would involve just checking if all the parts rendered, which is unnecessary here.

### Related issues

Relates to [RET-1302](https://linear.app/valora/issue/RET-1302/%5Bwallet%5D-add-new-reviewtransaction-component-to-earndepositbottomsheet)

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
