### PR TITLE
fix: protocol ids and release cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           # Full git history is needed for release notes
           fetch-depth: 0
-      - name: Debug Git Tags
-        run: git tag -l | sort -V
-      - name: Fetch all tags
-        run: git fetch --tags --force
       - id: auth
         uses: google-github-actions/auth@v2
         with:

--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -50,19 +50,10 @@ protocolIds: (
   | "allbridge"
   | "beefy"
   | "celo"
-  | "curve"
-  | "euler"
-  | "farcaster"
   | "fonbnk"
   | "mento"
-  | "morpho"
-  | "offchainlabs"
   | "somm"
-  | "tether"
-  | "ubeswap"
-  | "vana"
-  | "velodrome"
-  | "yearn")[];
+  | "vana")[];
 ```
 
 #### referrerId

--- a/packages/@divvi/mobile/src/divviProtocol/constants.ts
+++ b/packages/@divvi/mobile/src/divviProtocol/constants.ts
@@ -7,19 +7,10 @@ export const supportedProtocolIds = [
   'allbridge',
   'beefy',
   'celo',
-  'curve',
-  'euler',
-  'farcaster',
   'fonbnk',
   'mento',
-  'morpho',
-  'offchainlabs',
   'somm',
-  'tether',
-  'ubeswap',
   'vana',
-  'velodrome',
-  'yearn',
 ] as const
 
 export type SupportedProtocolId = (typeof supportedProtocolIds)[number]

--- a/packages/@divvi/mobile/test/RootStateSchema.json
+++ b/packages/@divvi/mobile/test/RootStateSchema.json
@@ -4636,7 +4636,7 @@
                     "$ref": "#/definitions/AppState"
                 },
                 "divviRegistrations": {
-                    "$ref": "#/definitions/{\"celo-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"celo-alfajores\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"ethereum-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"ethereum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"arbitrum-one\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"arbitrum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"op-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"op-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"polygon-pos-amoy\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"base-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"base-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;}"
+                    "$ref": "#/definitions/{\"celo-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"celo-alfajores\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-one\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-amoy\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;}"
                 },
                 "googleMobileServicesAvailable": {
                     "type": "boolean"
@@ -6684,7 +6684,7 @@
             ],
             "type": "object"
         },
-        "{\"celo-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"celo-alfajores\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"ethereum-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"ethereum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"arbitrum-one\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"arbitrum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"op-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"op-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"polygon-pos-amoy\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"base-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;\"base-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"curve\"|\"euler\"|\"farcaster\"|\"fonbnk\"|\"mento\"|\"morpho\"|\"offchainlabs\"|\"somm\"|\"tether\"|\"ubeswap\"|\"vana\"|\"velodrome\"|\"yearn\")[]|undefined;}": {
+        "{\"celo-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"celo-alfajores\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-one\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-amoy\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;}": {
             "additionalProperties": false,
             "properties": {
                 "arbitrum-one": {
@@ -6694,19 +6694,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6719,19 +6710,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6744,19 +6726,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6769,19 +6742,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6794,19 +6758,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6819,19 +6774,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6844,19 +6790,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6869,19 +6806,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6894,19 +6822,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6919,19 +6838,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6944,19 +6854,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },
@@ -6969,19 +6870,10 @@
                             "allbridge",
                             "beefy",
                             "celo",
-                            "curve",
-                            "euler",
-                            "farcaster",
                             "fonbnk",
                             "mento",
-                            "morpho",
-                            "offchainlabs",
                             "somm",
-                            "tether",
-                            "ubeswap",
-                            "vana",
-                            "velodrome",
-                            "yearn"
+                            "vana"
                         ],
                         "type": "string"
                     },


### PR DESCRIPTION
### Description

As the title.

The release workflow job does not need the removed steps to function (the fix ended up unrelated to these lines).

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
