### PR TITLE
fix: use sentry and walletconnect config params

### DIFF
--- a/apps/example/index.tsx
+++ b/apps/example/index.tsx
@@ -22,9 +22,12 @@ const App = createApp({
       : expoConfig.scheme
     : 'example',
   features: {
-    // Special case for e2e tests as it doesn't handle cloud backup
+    // Special cases to cover experimental features with e2e tests
     ...(process.env.EXPO_PUBLIC_DIVVI_E2E === 'true' && {
       cloudBackup: false,
+      walletConnect: {
+        projectId: '8f6f2517f4485c013849d38717ec90d1', // valora-e2e-client project
+      },
     }),
   },
   locales: {

--- a/packages/@divvi/mobile/src/config.ts
+++ b/packages/@divvi/mobile/src/config.ts
@@ -132,12 +132,7 @@ export const ZENDESK_API_KEY = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'ZEN
 export const STATSIG_API_KEY = appConfig.features?.statsig?.apiKey
 export const STATSIG_ENABLED = !isE2EEnv && !!STATSIG_API_KEY
 export const SEGMENT_API_KEY = appConfig.features?.segment?.apiKey
-export const SENTRY_CLIENT_URL = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'SENTRY_CLIENT_URL')
 export const BIDALI_URL = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'BIDALI_URL')
-export const WALLET_CONNECT_PROJECT_ID =
-  keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'WALLET_CONNECT_PROJECT_ID') ??
-  // valora-e2e-client project in the WC project dashboard
-  '8f6f2517f4485c013849d38717ec90d1'
 export const AUTH0_CLIENT_ID =
   DEFAULT_TESTNET === 'mainnet'
     ? 'FS2sPfMvDBKy0udOoCbc4ao8HakvAR6b'

--- a/packages/@divvi/mobile/src/sentry/Sentry.ts
+++ b/packages/@divvi/mobile/src/sentry/Sentry.ts
@@ -1,11 +1,7 @@
 import * as Sentry from '@sentry/react-native'
 import DeviceInfo from 'react-native-device-info'
-import {
-  APP_BUNDLE_ID,
-  DEFAULT_SENTRY_TRACES_SAMPLE_RATE,
-  SENTRY_CLIENT_URL,
-  SENTRY_ENABLED,
-} from 'src/config'
+import { getAppConfig } from 'src/appConfig'
+import { APP_BUNDLE_ID, DEFAULT_SENTRY_TRACES_SAMPLE_RATE, SENTRY_ENABLED } from 'src/config'
 import Logger from 'src/utils/Logger'
 import networkConfig from 'src/web3/networkConfig'
 import { currentAccountSelector } from 'src/web3/selectors'
@@ -23,7 +19,8 @@ export function initializeSentry() {
     return
   }
 
-  if (!SENTRY_CLIENT_URL) {
+  const sentryClientUrl = getAppConfig().features?.sentry?.clientUrl
+  if (!sentryClientUrl) {
     Logger.info(TAG, 'installSentry', 'Sentry URL not found, skipping installation')
     return
   }
@@ -49,7 +46,7 @@ export function initializeSentry() {
   })
 
   Sentry.init({
-    dsn: SENTRY_CLIENT_URL,
+    dsn: sentryClientUrl,
     environment: DeviceInfo.getBundleId(),
     enableAutoSessionTracking: true,
     integrations: [

--- a/packages/@divvi/mobile/src/walletConnect/saga.test.ts
+++ b/packages/@divvi/mobile/src/walletConnect/saga.test.ts
@@ -690,7 +690,7 @@ const v2ConnectionString =
 
 describe('initialiseWalletConnect', () => {
   const origin = WalletConnectPairingOrigin.Deeplink
-  it('initializes v2 if enabled', async () => {
+  it('initializes v2 if enabled and there is a wallet connect project id', async () => {
     jest.mocked(getAppConfig).mockReturnValue({
       displayName: 'Test App',
       deepLinkUrlScheme: 'testapp',

--- a/packages/@divvi/mobile/src/walletConnect/saga.ts
+++ b/packages/@divvi/mobile/src/walletConnect/saga.ts
@@ -11,7 +11,8 @@ import { WalletConnectEvents } from 'src/analytics/Events'
 import { WalletConnect2Properties } from 'src/analytics/Properties'
 import { DappRequestOrigin, WalletConnectPairingOrigin } from 'src/analytics/types'
 import { getDappRequestOrigin } from 'src/app/utils'
-import { APP_NAME, DEEP_LINK_URL_SCHEME, WALLET_CONNECT_PROJECT_ID } from 'src/config'
+import { getAppConfig } from 'src/appConfig'
+import { APP_NAME, DEEP_LINK_URL_SCHEME } from 'src/config'
 import { activeDappSelector } from 'src/dapps/selectors'
 import { ActiveDapp } from 'src/dapps/types'
 import i18n from 'src/i18n'
@@ -133,9 +134,10 @@ function* createWalletConnectChannel() {
   if (!client) {
     Logger.debug(TAG + '@createWalletConnectChannel', `init start`)
     const { links } = getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.APP_CONFIG])
+    const appConfig = yield* call(getAppConfig)
     client = yield* call([WalletKit, 'init'], {
       core: new Core({
-        projectId: WALLET_CONNECT_PROJECT_ID,
+        projectId: appConfig.features?.walletConnect?.projectId,
         relayUrl: networkConfig.walletConnectEndpoint,
       }),
       metadata: {
@@ -842,8 +844,9 @@ export function* initialiseWalletConnectV2(uri: string, origin: WalletConnectPai
 export function isWalletConnectEnabled(uri: string) {
   const { version } = parseUri(uri)
   const walletConnectV2Disabled = getFeatureGate(StatsigFeatureGates.DISABLE_WALLET_CONNECT_V2)
+  const walletConnectProjectId = getAppConfig().features?.walletConnect?.projectId
 
-  return !walletConnectV2Disabled && version === 2
+  return walletConnectProjectId && !walletConnectV2Disabled && version === 2
 }
 
 export function* initialiseWalletConnect(uri: string, origin: WalletConnectPairingOrigin) {

--- a/packages/@divvi/mobile/src/walletConnect/saga.ts
+++ b/packages/@divvi/mobile/src/walletConnect/saga.ts
@@ -846,7 +846,7 @@ export function isWalletConnectEnabled(uri: string) {
   const walletConnectV2Disabled = getFeatureGate(StatsigFeatureGates.DISABLE_WALLET_CONNECT_V2)
   const walletConnectProjectId = getAppConfig().features?.walletConnect?.projectId
 
-  return walletConnectProjectId && !walletConnectV2Disabled && version === 2
+  return !!walletConnectProjectId && !walletConnectV2Disabled && version === 2
 }
 
 export function* initialiseWalletConnect(uri: string, origin: WalletConnectPairingOrigin) {


### PR DESCRIPTION
### Description

As the title

### Test plan

CI passes

### Related issues

- Related to ENG-181

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
