### PR TITLE
fix: add needed cloud backup params to app config

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -163,10 +163,10 @@ android {
         resValue "bool", "is_profiling_build", System.getenv("IS_PROFILING_BUILD") ?: "false"
         buildConfigField "String", "APP_REGISTRY_NAME", "\"${project.env.get("APP_REGISTRY_NAME")}\""
 
-        manifestPlaceholders = [
+        manifestPlaceholders = project.env.get("AUTH0_DOMAIN") ? [
             auth0Domain: project.env.get("AUTH0_DOMAIN"),
-            auth0Scheme: "${applicationId}.auth0",
-        ]
+            auth0Scheme: "${applicationId}.auth0"
+        ] : [:]
 
     }
 

--- a/apps/example/index.tsx
+++ b/apps/example/index.tsx
@@ -24,7 +24,9 @@ const App = createApp({
   features: {
     // Special case for e2e tests as it doesn't handle cloud backup
     ...(process.env.EXPO_PUBLIC_DIVVI_E2E === 'true' && {
-      cloudBackup: false,
+      walletConnect: {
+        projectId: '8f6f2517f4485c013849d38717ec90d1', // valora-e2e-client project
+      },
     }),
   },
   locales: {

--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -40,7 +40,7 @@ Defined in: [packages/@divvi/mobile/src/public/types.tsx:26](https://github.com/
 optional divviProtocol: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:220](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L220)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:224](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L224)
 
 #### protocolIds
 
@@ -70,7 +70,7 @@ referrerId: string
 optional experimental: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:190](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L190)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:194](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L194)
 
 Experimental features that may change or be removed in future versions.
 These features are not part of the stable configuration API and should be used with caution.
@@ -210,7 +210,25 @@ Defined in: [packages/@divvi/mobile/src/public/types.tsx:142](https://github.com
 #### cloudBackup?
 
 ```ts
-optional cloudBackup: boolean;
+optional cloudBackup: object;
+```
+
+##### cloudBackup.auth0ClientId
+
+```ts
+auth0ClientId: string
+```
+
+##### cloudBackup.auth0Domain
+
+```ts
+auth0Domain: string
+```
+
+##### cloudBackup.web3AuthClientId
+
+```ts
+web3AuthClientId: string
 ```
 
 #### segment?
@@ -299,7 +317,7 @@ optional locales: Partial<{
 }>;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:163](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L163)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:167](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L167)
 
 Optional copies overwrite. This field should contain the same language keys as @interxyz/mobile.
 TODO: Eventually, we want to make this fully type-safe (maybe with generics?)
@@ -312,7 +330,7 @@ TODO: Eventually, we want to make this fully type-safe (maybe with generics?)
 optional networks: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:180](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L180)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:184](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L184)
 
 ---
 

--- a/docs/reference/type-aliases/NetworkId.md
+++ b/docs/reference/type-aliases/NetworkId.md
@@ -22,4 +22,4 @@ type NetworkId =
   | 'base-sepolia'
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:227](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L227)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:231](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L231)

--- a/packages/@divvi/mobile/src/app/App.tsx
+++ b/packages/@divvi/mobile/src/app/App.tsx
@@ -100,7 +100,7 @@ export class App extends React.Component<Props> {
       <SafeAreaProvider>
         <Provider store={store}>
           <PersistGate persistor={persistor}>
-            {!!this.cloudBackupConfig ? (
+            {this.cloudBackupConfig ? (
               <Auth0Provider
                 domain={this.cloudBackupConfig.auth0Domain}
                 clientId={this.cloudBackupConfig.auth0ClientId}

--- a/packages/@divvi/mobile/src/config.ts
+++ b/packages/@divvi/mobile/src/config.ts
@@ -96,11 +96,6 @@ export const FIREBASE_ENABLED = stringToBoolean(Config.FIREBASE_ENABLED || 'true
 export const SHOW_TESTNET_BANNER = stringToBoolean(Config.SHOW_TESTNET_BANNER || 'false')
 export const SENTRY_ENABLED = stringToBoolean(Config.SENTRY_ENABLED || 'false')
 
-export const WEB3AUTH_CLIENT_ID =
-  DEFAULT_TESTNET === 'mainnet'
-    ? 'BAJWXF8YqQSoNtdfX3z-vxgkZ0ZfN0hJVT0eGuf9BqoRbojNIxthU0wnW0oBScduV6XLeEePSmVhHQXuaqBMjcw'
-    : 'BH-yuQkutyRCHMwcTQu_zSpkbG5fGeJEoc45DeoW4krzESwLD6qhQXRCuTSrFU_-qbvIvLcZhUJv9G5xmoFip8M'
-
 // SECRETS
 export const ALCHEMY_ETHEREUM_API_KEY = keyOrUndefined(
   experimentalConfig,
@@ -138,12 +133,6 @@ export const WALLET_CONNECT_PROJECT_ID =
   keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'WALLET_CONNECT_PROJECT_ID') ??
   // valora-e2e-client project in the WC project dashboard
   '8f6f2517f4485c013849d38717ec90d1'
-export const AUTH0_CLIENT_ID =
-  DEFAULT_TESTNET === 'mainnet'
-    ? 'FS2sPfMvDBKy0udOoCbc4ao8HakvAR6b'
-    : 'YgsHPq93Egfap5Wc4iEQlGyQMqjLeBf2'
-
-export const AUTH0_DOMAIN = configOrThrow('AUTH0_DOMAIN')
 
 export const SPEND_MERCHANT_LINKS: SpendMerchant[] = [
   {

--- a/packages/@divvi/mobile/src/keylessBackup/web3auth.test.ts
+++ b/packages/@divvi/mobile/src/keylessBackup/web3auth.test.ts
@@ -1,4 +1,5 @@
 import { Torus } from '@toruslabs/torus.js'
+import { getAppConfig } from 'src/appConfig'
 import { getTorusPrivateKey } from './web3auth'
 
 jest.mock('@toruslabs/torus.js')
@@ -42,6 +43,18 @@ describe('getTorusPrivateKey', () => {
       getPublicAddress: mockGetPublicAddress,
       retrieveShares: mockRetrieveShares,
     } as any)
+    jest.mocked(getAppConfig).mockReturnValue({
+      displayName: 'Test App',
+      deepLinkUrlScheme: 'testapp',
+      registryName: 'test',
+      features: {
+        cloudBackup: {
+          auth0Domain: 'auth0Domain',
+          auth0ClientId: 'auth0ClientId',
+          web3AuthClientId: 'web3AuthClientId',
+        },
+      },
+    })
   })
 
   it('should retrun private key successfully', async () => {

--- a/packages/@divvi/mobile/src/keylessBackup/web3auth.ts
+++ b/packages/@divvi/mobile/src/keylessBackup/web3auth.ts
@@ -1,12 +1,18 @@
 import { NodeDetailManager } from '@toruslabs/fetch-node-details'
 import { Torus } from '@toruslabs/torus.js'
 import { jwtDecode } from 'jwt-decode'
-import { TORUS_NETWORK, WEB3AUTH_CLIENT_ID } from 'src/config'
+import { getAppConfig } from 'src/appConfig'
+import { TORUS_NETWORK } from 'src/config'
 import Logger from 'src/utils/Logger'
 
 const TAG = 'keylessBackup/torus'
 
 export async function getTorusPrivateKey({ verifier, jwt }: { verifier: string; jwt: string }) {
+  const web3AuthClientId = getAppConfig().features?.cloudBackup?.web3AuthClientId
+  if (!web3AuthClientId) {
+    throw new Error('web3AuthClientId not set in app config')
+  }
+
   // largely copied from CustomAuth triggerLogin
   Logger.debug(TAG, `decoding jwt ${jwt}`)
   const sub = jwtDecode<{ sub: string }>(jwt).sub
@@ -15,7 +21,7 @@ export async function getTorusPrivateKey({ verifier, jwt }: { verifier: string; 
   })
   const torus = new Torus({
     network: TORUS_NETWORK,
-    clientId: WEB3AUTH_CLIENT_ID,
+    clientId: web3AuthClientId,
   })
   Logger.debug(TAG, `getting node details for verifier ${verifier} and sub ${sub}`)
   const { torusNodeEndpoints, torusNodePub, torusIndexes } = await nodeDetailManager.getNodeDetails(

--- a/packages/@divvi/mobile/src/public/createApp.ts
+++ b/packages/@divvi/mobile/src/public/createApp.ts
@@ -48,7 +48,7 @@ export function createApp<const tabScreenConfigs extends TabScreenConfig[]>(
   Config.APP_STORE_ID = config.ios?.appStoreId
   Config.APP_DISPLAY_NAME = config.displayName
   Config.SENTRY_ENABLED = config.features?.sentry?.clientUrl ? 'true' : 'false'
-  Config.AUTH0_DOMAIN = 'auth.valora.xyz' // TODO: also set auth0ClientId and web3AuthClientId that are needed for cloud backup
+  Config.AUTH0_DOMAIN = config.features?.cloudBackup?.auth0Domain // Note that this needs to go through react-native-config as it is needed for the android build
   Config.ONBOARDING_FEATURES_ENABLED = getOnboardingFeatures(config)
   Config.DEEP_LINK_URL_SCHEME = config.deepLinkUrlScheme
   Config.APP_REGISTRY_NAME = config.registryName

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -144,7 +144,11 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
       clientUrl: string
     }
     // TODO: what's the marketing name for this?
-    cloudBackup?: boolean
+    cloudBackup?: {
+      auth0Domain: string
+      auth0ClientId: string
+      web3AuthClientId: string
+    }
     walletConnect?: {
       projectId: string
     }


### PR DESCRIPTION
### Description

As the title.

One thing to note is that the `AUTH0_DOMAIN` still needs to be declared in the .env files to be picked up at build time by the Android. 


### Test plan

n/a

### Related issues

- Related to ENG-181

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
