### PR TITLE
refactor(tokens): remove network id param from selectors

### DIFF
--- a/docs/reference/functions/navigate.md
+++ b/docs/reference/functions/navigate.md
@@ -10,7 +10,7 @@
 function navigate(...args): void
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/navigate.ts:62](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L62)
+Defined in: [packages/@divvi/mobile/src/public/navigate.ts:61](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L61)
 
 ## Parameters
 

--- a/docs/reference/functions/useWallet.md
+++ b/docs/reference/functions/useWallet.md
@@ -10,7 +10,7 @@
 function useWallet(): object
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/hooks/useWallet.ts:51](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/hooks/useWallet.ts#L51)
+Defined in: [packages/@divvi/mobile/src/public/hooks/useWallet.ts:39](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/hooks/useWallet.ts#L39)
 
 ## Returns
 

--- a/docs/reference/type-aliases/StackParamList.md
+++ b/docs/reference/type-aliases/StackParamList.md
@@ -10,7 +10,7 @@
 type StackParamList = object
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/navigate.ts:32](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L32)
+Defined in: [packages/@divvi/mobile/src/public/navigate.ts:31](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L31)
 
 ## Type declaration
 

--- a/packages/@divvi/mobile/src/analytics/AppAnalytics.ts
+++ b/packages/@divvi/mobile/src/analytics/AppAnalytics.ts
@@ -24,7 +24,6 @@ import { store } from 'src/redux/store'
 import { getDefaultStatsigUser } from 'src/statsig'
 import { ensureError } from 'src/utils/ensureError'
 import Logger from 'src/utils/Logger'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 import { Statsig } from 'statsig-react-native'
 import { sha256 } from 'viem'
 
@@ -308,7 +307,7 @@ class AppAnalytics {
 
   // Super props, i.e. props sent with all events
   private getSuperProps() {
-    const traits = getCurrentUserTraits(store.getState(), getSupportedNetworkIds())
+    const traits = getCurrentUserTraits(store.getState())
     // Prefix super props with `s` so they don't clash with events props
     const prefixedSuperProps = Object.fromEntries(
       Object.entries({

--- a/packages/@divvi/mobile/src/analytics/saga.test.ts
+++ b/packages/@divvi/mobile/src/analytics/saga.test.ts
@@ -4,7 +4,6 @@ import { select } from 'redux-saga/effects'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { updateUserTraits } from 'src/analytics/saga'
 import { getCurrentUserTraits } from 'src/analytics/selectors'
-import networkConfig from 'src/web3/networkConfig'
 
 jest.mock('src/config', () => ({
   ...jest.requireActual('src/config'),
@@ -34,7 +33,7 @@ describe(updateUserTraits, () => {
     }
 
     await expectSaga(updateUserTraits)
-      .provide([[select(getCurrentUserTraits, [networkConfig.defaultNetworkId]), dynamic(traits)]])
+      .provide([[select(getCurrentUserTraits), dynamic(traits)]])
       // dispatch 3 times, so select is called 4 times (see implementation)
       .dispatch({ type: 'TEST_ACTION_TYPE' })
       .dispatch({ type: 'TEST_ACTION_TYPE' })

--- a/packages/@divvi/mobile/src/analytics/saga.ts
+++ b/packages/@divvi/mobile/src/analytics/saga.ts
@@ -1,12 +1,11 @@
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { getCurrentUserTraits } from 'src/analytics/selectors'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 import { call, select, spawn, take } from 'typed-redux-saga'
 
 export function* updateUserTraits() {
   let prevTraits
   while (true) {
-    const traits = yield* select(getCurrentUserTraits, getSupportedNetworkIds())
+    const traits = yield* select(getCurrentUserTraits)
     if (traits !== prevTraits) {
       const { walletAddress } = traits
       yield* call([AppAnalytics, 'identify'], walletAddress as string | null, traits)

--- a/packages/@divvi/mobile/src/analytics/selectors.test.ts
+++ b/packages/@divvi/mobile/src/analytics/selectors.test.ts
@@ -345,20 +345,24 @@ const expectedTraitsForAllNetworks = {
   totalBalanceUsd: 20831.636783945,
   totalCeloAlfajoresBalanceUsd: 5681.606783945,
   totalEthereumSepoliaBalanceUsd: 15150.03,
+  totalArbitrumSepoliaBalanceUsd: 0,
+  totalOpSepoliaBalanceUsd: 0,
+  totalBaseSepoliaBalanceUsd: 0,
   totalPositionsBalanceUsd: 83.34234,
   walletAddress: '0x0000000000000000000000000000000000007e57',
   hasTokenBalance: true,
   hasCeloAlfajoresTokenBalance: true,
   hasEthereumSepoliaTokenBalance: true,
+  hasArbitrumSepoliaTokenBalance: false,
+  hasOpSepoliaTokenBalance: false,
+  hasBaseSepoliaTokenBalance: false,
   pointsBalance: '50',
 }
 
 describe('getCurrentUserTraits', () => {
   it('returns the current user traits with tokens from multiple networks', () => {
     const state = getMockStoreData(mockState)
-    expect(
-      getCurrentUserTraits(state, [NetworkId['celo-alfajores'], NetworkId['ethereum-sepolia']])
-    ).toStrictEqual(expectedTraitsForAllNetworks)
+    expect(getCurrentUserTraits(state)).toStrictEqual(expectedTraitsForAllNetworks)
   })
   it('sets correct hasTokenBalance fields if all tokens in one network have no balance', () => {
     const mockTokenBalances = {
@@ -373,9 +377,7 @@ describe('getCurrentUserTraits', () => {
       },
     }
     const state = getMockStoreData({ ...mockState, tokens: { tokenBalances: mockTokenBalances } })
-    expect(
-      getCurrentUserTraits(state, [NetworkId['celo-alfajores'], NetworkId['ethereum-sepolia']])
-    ).toStrictEqual({
+    expect(getCurrentUserTraits(state)).toStrictEqual({
       ...expectedTraitsForAllNetworks,
       ethBalance: 0,
       netWorthUsd: 5764.949123945,

--- a/packages/@divvi/mobile/src/analytics/selectors.ts
+++ b/packages/@divvi/mobile/src/analytics/selectors.ts
@@ -19,12 +19,11 @@ import {
   positionsByBalanceUsdSelector,
   totalPositionsBalanceUsdSelector,
 } from 'src/positions/selectors'
-import { RootState } from 'src/redux/reducers'
 import { tokensListSelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
 import { sortByUsdBalance } from 'src/tokens/utils'
-import { NetworkId } from 'src/transactions/types'
 import { getRegionCodeFromCountryCode } from 'src/utils/phoneNumbers'
 import { rawWalletAddressSelector } from 'src/web3/selectors'
+import { getSupportedNetworkIds } from 'src/web3/utils'
 
 function toPascalCase(str: string) {
   const camelCaseStr = camelCase(str)
@@ -94,7 +93,6 @@ export const getCurrentUserTraits = createSelector(
     backupCompletedSelector,
     pincodeTypeSelector,
     pointsBalanceSelector,
-    (_state: RootState, networkIds: NetworkId[]) => networkIds,
   ],
   (
     rawWalletAddress,
@@ -114,11 +112,11 @@ export const getCurrentUserTraits = createSelector(
     numberVerifiedCentralized,
     hasCompletedBackup,
     pincodeType,
-    pointsBalance,
-    networkIds
+    pointsBalance
   ) => {
     const feeTokenIds = new Set(feeTokens.map(({ tokenId }) => tokenId))
     const tokensByUsdBalance = tokensWithBalance.sort(sortByUsdBalance)
+    const networkIds = getSupportedNetworkIds()
 
     let totalBalanceUsd = new BigNumber(0)
     const totalBalanceUsdByNetworkIdBigNumber: Record<string, BigNumber> = Object.fromEntries(

--- a/packages/@divvi/mobile/src/components/TokenBalance.tsx
+++ b/packages/@divvi/mobile/src/components/TokenBalance.tsx
@@ -47,7 +47,6 @@ import {
   useTotalTokenBalance,
 } from 'src/tokens/hooks'
 import { tokenFetchErrorSelector } from 'src/tokens/selectors'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 
 function TokenBalance({
   style = styles.balance,
@@ -58,12 +57,11 @@ function TokenBalance({
   singleTokenViewEnabled?: boolean
   showBalanceToggle?: boolean
 }) {
-  const supportedNetworkIds = getSupportedNetworkIds()
-  const tokensWithUsdValue = useTokensWithUsdValue(supportedNetworkIds)
+  const tokensWithUsdValue = useTokensWithUsdValue()
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol)
   const totalTokenBalanceLocal = useTotalTokenBalance()
   const tokenFetchError = useSelector(tokenFetchErrorSelector)
-  const tokensAreStale = useTokenPricesAreStale(supportedNetworkIds)
+  const tokensAreStale = useTokenPricesAreStale()
   // TODO(ACT-1095): Update these to filter out unsupported networks once positions support non-Celo chains
   const totalPositionsBalanceUsd = useSelector(totalPositionsBalanceUsdSelector)
   const totalPositionsBalanceLocal = useDollarsToLocalAmount(totalPositionsBalanceUsd)
@@ -136,8 +134,7 @@ function HideBalanceButton({ hideBalance }: { hideBalance: boolean }) {
 function useErrorMessageWithRefresh() {
   const { t } = useTranslation()
 
-  const supportedNetworkIds = getSupportedNetworkIds()
-  const tokensInfoUnavailable = useTokensInfoUnavailable(supportedNetworkIds)
+  const tokensInfoUnavailable = useTokensInfoUnavailable()
   const tokenFetchError = useSelector(tokenFetchErrorSelector)
   const localCurrencyError = useSelector(localCurrencyExchangeRateErrorSelector)
 

--- a/packages/@divvi/mobile/src/earn/EarnHome.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnHome.tsx
@@ -80,8 +80,7 @@ export default function EarnHome({ navigation, route }: Props) {
     paddingBottom: Math.max(insets.bottom, Spacing.Regular16),
   }
 
-  const supportedNetworkIds = [...new Set(pools.map((pool) => pool.networkId))]
-  const allTokens = useSelector((state) => tokensByIdSelector(state, supportedNetworkIds))
+  const allTokens = useSelector(tokensByIdSelector)
 
   // Scroll Aware Header
   const scrollPosition = useSharedValue(0)

--- a/packages/@divvi/mobile/src/earn/PoolCard.tsx
+++ b/packages/@divvi/mobile/src/earn/PoolCard.tsx
@@ -43,7 +43,7 @@ export default function PoolCard({
   } = pool
   const { t } = useTranslation()
   const appConfig = getAppConfig()
-  const allTokens = useSelector((state) => tokensByIdSelector(state, [networkId]))
+  const allTokens = useSelector(tokensByIdSelector)
   const tokensInfo = useMemo(() => {
     return tokens
       .map((token) => allTokens[token.tokenId])

--- a/packages/@divvi/mobile/src/earn/TabEarn.tsx
+++ b/packages/@divvi/mobile/src/earn/TabEarn.tsx
@@ -66,8 +66,7 @@ function TabHome({ navigation, route }: Props) {
 
   const insets = useSafeAreaInsets()
 
-  const supportedNetworkIds = [...new Set(pools.map((pool) => pool.networkId))]
-  const allTokens = useSelector((state) => tokensByIdSelector(state, supportedNetworkIds))
+  const allTokens = useSelector(tokensByIdSelector)
 
   // Scroll Aware Header
   const scrollPosition = useSharedValue(0)

--- a/packages/@divvi/mobile/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
+++ b/packages/@divvi/mobile/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
@@ -179,7 +179,7 @@ type Props = NativeStackScreenProps<StackParamList, Screens.EarnPoolInfoScreen>
 export default function EarnPoolInfoScreen({ route, navigation }: Props) {
   const { pool } = route.params
   const { networkId, tokens, displayProps, appName, dataProps, appId, positionId, balance } = pool
-  const allTokens = useSelector((state) => tokensByIdSelector(state, [networkId]))
+  const allTokens = useSelector(tokensByIdSelector)
   const tokensInfo = useMemo(() => {
     return tokens
       .map((token) => allTokens[token.tokenId])

--- a/packages/@divvi/mobile/src/earn/saga.ts
+++ b/packages/@divvi/mobile/src/earn/saga.ts
@@ -96,9 +96,7 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
     return
   }
 
-  const tokensById = yield* select((state) =>
-    tokensByIdSelector(state, { networkIds: [pool.networkId], includePositionTokens: true })
-  )
+  const tokensById = yield* select((state) => tokensByIdSelector(state, true))
 
   const trackedTxs: TrackedTx[] = []
   const poolNetworkId = pool.networkId

--- a/packages/@divvi/mobile/src/earn/saga.ts
+++ b/packages/@divvi/mobile/src/earn/saga.ts
@@ -96,7 +96,9 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
     return
   }
 
-  const tokensById = yield* select((state) => tokensByIdSelector(state, true))
+  const tokensById = yield* select((state) =>
+    tokensByIdSelector(state, { includePositionTokens: true })
+  )
 
   const trackedTxs: TrackedTx[] = []
   const poolNetworkId = pool.networkId

--- a/packages/@divvi/mobile/src/fiatconnect/saga.test.ts
+++ b/packages/@divvi/mobile/src/fiatconnect/saga.test.ts
@@ -2031,7 +2031,7 @@ describe('Fiatconnect saga', () => {
         await expectSaga(handleCreateFiatConnectTransfer, action)
           .provide([
             [call(_initiateTransferWithProvider, action), { transferAddress, transferId }],
-            [select(tokensByIdSelector, [networkId]), { [mockCusdTokenId]: mockCusdTokenBalance }],
+            [select(tokensByIdSelector), { [mockCusdTokenId]: mockCusdTokenBalance }],
             [
               call(_initiateSendTxToProvider, {
                 transferAddress,
@@ -2081,7 +2081,7 @@ describe('Fiatconnect saga', () => {
         await expectSaga(handleCreateFiatConnectTransfer, action)
           .provide([
             [call(_initiateTransferWithProvider, action), { transferAddress }],
-            [select(tokensByIdSelector, [networkId]), { [mockCusdTokenId]: mockCusdTokenBalance }],
+            [select(tokensByIdSelector), { [mockCusdTokenId]: mockCusdTokenBalance }],
             [
               call(_initiateSendTxToProvider, {
                 transferAddress,
@@ -2119,7 +2119,7 @@ describe('Fiatconnect saga', () => {
         await expectSaga(handleCreateFiatConnectTransfer, action)
           .provide([
             [call(_initiateTransferWithProvider, action), { transferAddress }],
-            [select(tokensByIdSelector, [networkId]), { [mockCusdTokenId]: mockCusdTokenBalance }],
+            [select(tokensByIdSelector), { [mockCusdTokenId]: mockCusdTokenBalance }],
             [
               call(_initiateSendTxToProvider, {
                 transferAddress,

--- a/packages/@divvi/mobile/src/fiatconnect/saga.ts
+++ b/packages/@divvi/mobile/src/fiatconnect/saga.ts
@@ -1021,7 +1021,7 @@ export function* handleCreateFiatConnectTransfer(
         throw new Error('Missing networkId for cash out')
       }
 
-      const tokenList = yield* select(tokensByIdSelector, [networkId])
+      const tokenList = yield* select(tokensByIdSelector)
       const tokenId = fiatConnectQuote.getTokenId()
       const tokenInfo = tokenList[tokenId]
       if (!tokenInfo) {

--- a/packages/@divvi/mobile/src/jumpstart/saga.ts
+++ b/packages/@divvi/mobile/src/jumpstart/saga.ts
@@ -97,7 +97,7 @@ export function* dispatchPendingERC20Transactions(
   networkId: NetworkId,
   transactionReceipts: TransactionReceipt[]
 ) {
-  const tokensById = yield* select((state) => tokensByIdSelector(state, [networkId]))
+  const tokensById = yield* select(tokensByIdSelector)
 
   for (const { transactionHash, logs } of transactionReceipts) {
     const parsedLogs = parseEventLogs({

--- a/packages/@divvi/mobile/src/points/cardDefinitions.tsx
+++ b/packages/@divvi/mobile/src/points/cardDefinitions.tsx
@@ -14,7 +14,6 @@ import colors from 'src/styles/colors'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalances } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 
 const TAG = 'Points/cardDefinitions'
 
@@ -55,7 +54,7 @@ export function useGetHistoryDefinition(): (
   history: ClaimHistoryCardItem
 ) => HistoryCardMetadata | undefined {
   const { t } = useTranslation()
-  const tokensById = useSelector((state) => tokensByIdSelector(state, getSupportedNetworkIds()))
+  const tokensById = useSelector(tokensByIdSelector)
 
   return (history: ClaimHistoryCardItem) => {
     switch (history.activityId) {

--- a/packages/@divvi/mobile/src/positions/selectors.test.ts
+++ b/packages/@divvi/mobile/src/positions/selectors.test.ts
@@ -13,6 +13,11 @@ import { NetworkId } from 'src/transactions/types'
 import { mockPositions, mockShortcuts } from 'test/values'
 
 jest.mock('src/statsig')
+jest.mock('src/web3/utils', () => ({
+  ...jest.requireActual('src/web3/utils'),
+  // some tests use mainnet and some testnet
+  getSupportedNetworkIds: jest.fn(() => ['celo-mainnet', 'celo-alfajores']),
+}))
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/packages/@divvi/mobile/src/positions/selectors.ts
+++ b/packages/@divvi/mobile/src/positions/selectors.ts
@@ -12,7 +12,6 @@ import { RootState } from 'src/redux/reducers'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { tokensByIdSelector } from 'src/tokens/selectors'
-import { NetworkId } from 'src/transactions/types'
 import { isPresent } from 'src/utils/typescript'
 import networkConfig from 'src/web3/networkConfig'
 import { getPositionBalanceUsd } from './getPositionBalanceUsd'
@@ -55,10 +54,7 @@ export const earnPositionsSelector = createSelector(
 )
 
 export const totalPositionsBalanceUsdSelector = createSelector(
-  [
-    positionsWithBalanceSelector,
-    (state: RootState) => tokensByIdSelector(state, Object.values(NetworkId)),
-  ],
+  [positionsWithBalanceSelector, tokensByIdSelector],
   (positions, tokensById) => {
     if (positions.length === 0) {
       return null

--- a/packages/@divvi/mobile/src/public/hooks/useWallet.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useWallet.ts
@@ -12,32 +12,20 @@
  *   - when using "import type" - use relative paths (e.g. ../../redux/hooks)
  */
 
-import { useMemo } from 'react'
 import type { EarnPosition } from 'src/positions/types'
 import type { UseSelector } from '../../redux/hooks'
 import type { SortedTokensWithBalanceOrShowZeroBalanceSelector } from '../../tokens/selectors'
 import type { TokenBalance } from '../../tokens/slice'
-import type { GetSupportedNetworkIdsForSend } from '../../tokens/utils'
-import type { NetworkId } from '../../transactions/types'
 import type { WalletAddressSelector } from '../../web3/selectors'
 
 function useTokens() {
   const useSelector = require('../../redux/hooks').useSelector as UseSelector
-  const getSupportedNetworkIdsForSend = require('../../tokens/utils')
-    .getSupportedNetworkIdsForSend as GetSupportedNetworkIdsForSend
   const sortedTokensWithBalanceOrShowZeroBalanceSelector = require('../../tokens/selectors')
     .sortedTokensWithBalanceOrShowZeroBalanceSelector as SortedTokensWithBalanceOrShowZeroBalanceSelector
 
-  const supportedNetworkIds = getSupportedNetworkIdsForSend().join(',')
-  const memoizedNetworkIds = useMemo(
-    () => supportedNetworkIds.split(',') as NetworkId[],
-    [supportedNetworkIds]
-  )
   // explicitly allow zero state tokens to be shown for exploration purposes for
   // new users with no balance
-  const tokens = useSelector((state) =>
-    sortedTokensWithBalanceOrShowZeroBalanceSelector(state, memoizedNetworkIds)
-  )
+  const tokens = useSelector(sortedTokensWithBalanceOrShowZeroBalanceSelector)
   return tokens
 }
 

--- a/packages/@divvi/mobile/src/public/navigate.ts
+++ b/packages/@divvi/mobile/src/public/navigate.ts
@@ -8,7 +8,6 @@ import type { Store } from '../redux/store'
 import type { TokensByIdSelector } from '../tokens/selectors'
 import type { NetworkId as InternalNetworkId } from '../transactions/types'
 import type { LoggerType } from '../utils/Logger'
-import type { NetworkConfig } from '../web3/networkConfig'
 import type { NetworkId } from './types'
 
 const TAG = 'public/navigate'
@@ -64,7 +63,6 @@ export function navigate(...args: NavigateArgs): void {
   const Logger = require('../utils/Logger').default as LoggerType
   const store = require('../redux/store').store as Store
   const tokensByIdSelector = require('../tokens/selectors').tokensByIdSelector as TokensByIdSelector
-  const networkConfig = require('../web3/networkConfig').default as NetworkConfig
   const Screens = require('../navigator/Screens').Screens as ScreensType
   const FiatExchangeFlow = require('../fiatExchanges/types')
     .FiatExchangeFlow as FiatExchangeFlowType
@@ -96,10 +94,7 @@ export function navigate(...args: NavigateArgs): void {
       break
     case 'Add':
       if (params?.tokenId) {
-        const networkIds = Object.values(networkConfig.networkToNetworkId)
-        const tokens = tokensByIdSelector(store.getState(), {
-          networkIds,
-        })
+        const tokens = tokensByIdSelector(store.getState())
         const tokenInfo = params ? tokens[params.tokenId] : undefined
         if (tokenInfo && tokenInfo.isCashInEligible) {
           // TODO: we should refactor FiatExchangeAmount so it can accept just a tokenId, without the need for the tokenSymbol

--- a/packages/@divvi/mobile/src/send/SendEnterAmount.tsx
+++ b/packages/@divvi/mobile/src/send/SendEnterAmount.tsx
@@ -15,7 +15,6 @@ import { sortedTokensWithBalanceOrShowZeroBalanceSelector } from 'src/tokens/sel
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.SendEnterAmount>
 
@@ -23,12 +22,9 @@ const TAG = 'SendEnterAmount'
 
 function SendEnterAmount({ route }: Props) {
   const { defaultTokenIdOverride, origin, recipient, isFromScan, forceTokenId } = route.params
-  const supportedNetworkIds = getSupportedNetworkIds()
   // explicitly allow zero state tokens to be shown for exploration purposes for
   // new users with no balance
-  const tokens = useSelector((state) =>
-    sortedTokensWithBalanceOrShowZeroBalanceSelector(state, supportedNetworkIds)
-  )
+  const tokens = useSelector(sortedTokensWithBalanceOrShowZeroBalanceSelector)
   const lastUsedTokenId = useSelector(lastUsedTokenIdSelector)
 
   const defaultToken = useMemo(() => {

--- a/packages/@divvi/mobile/src/send/utils.ts
+++ b/packages/@divvi/mobile/src/send/utils.ts
@@ -18,7 +18,6 @@ import { TokenBalance } from 'src/tokens/slice'
 import { convertLocalToTokenAmount } from 'src/tokens/utils'
 import { Currency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 import { call, put, select } from 'typed-redux-saga'
 
 const TAG = 'send/utils'
@@ -49,10 +48,7 @@ export function* handleSendPaymentData({
     })
   )
 
-  const supportedNetworkIds = yield* call(getSupportedNetworkIds)
-  const tokens: TokenBalance[] = yield* select((state) =>
-    tokensListSelector(state, supportedNetworkIds)
-  )
+  const tokens: TokenBalance[] = yield* select(tokensListSelector)
   const tokenInfo = tokens.find((token) => token?.symbol === (data.token ?? Currency.Dollar))
 
   if (!tokenInfo?.priceUsd) {

--- a/packages/@divvi/mobile/src/swap/SwapScreen.tsx
+++ b/packages/@divvi/mobile/src/swap/SwapScreen.tsx
@@ -59,7 +59,6 @@ import { parseInputAmount } from 'src/utils/parsing'
 import { getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
 import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
 import networkConfig from 'src/web3/networkConfig'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 import { v4 as uuidv4 } from 'uuid'
 
 const TAG = 'SwapScreen'
@@ -251,7 +250,7 @@ export function SwapScreen({ route }: Props) {
 
   const { swappableFromTokens, swappableToTokens, areSwapTokensShuffled } = useSwappableTokens()
 
-  const tokensById = useSelector((state) => tokensByIdSelector(state, getSupportedNetworkIds()))
+  const tokensById = useSelector(tokensByIdSelector)
 
   const initialFromTokenId = route.params?.fromTokenId
   const initialToTokenId = route.params?.toTokenId

--- a/packages/@divvi/mobile/src/swap/SwapScreenV2.tsx
+++ b/packages/@divvi/mobile/src/swap/SwapScreenV2.tsx
@@ -59,7 +59,6 @@ import Logger from 'src/utils/Logger'
 import { getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
 import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
 import networkConfig from 'src/web3/networkConfig'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 import { v4 as uuidv4 } from 'uuid'
 
 const TAG = 'SwapScreen'
@@ -118,7 +117,7 @@ export default function SwapScreenV2({ route }: Props) {
 
   const currentSwap = useSelector(currentSwapSelector)
   const localCurrency = useSelector(getLocalCurrencyCode)
-  const tokensById = useSelector((state) => tokensByIdSelector(state, getSupportedNetworkIds()))
+  const tokensById = useSelector(tokensByIdSelector)
   const crossChainFeeCurrency = useSelector((state) =>
     feeCurrenciesSelector(state, fromToken?.networkId || networkConfig.defaultNetworkId)
   ).find((token) => token.isNative)

--- a/packages/@divvi/mobile/src/swap/saga.ts
+++ b/packages/@divvi/mobile/src/swap/saga.ts
@@ -29,7 +29,7 @@ import { safely } from 'src/utils/safely'
 import { publicClient } from 'src/viem'
 import { getPreparedTransactions } from 'src/viem/preparedTransactionSerialization'
 import { sendPreparedTransactions } from 'src/viem/saga'
-import { getNetworkFromNetworkId, getSupportedNetworkIds } from 'src/web3/utils'
+import { getNetworkFromNetworkId } from 'src/web3/utils'
 import { call, put, select, takeEvery } from 'typed-redux-saga'
 import { decodeFunctionData, erc20Abi } from 'viem'
 
@@ -92,7 +92,7 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
     serializablePreparedTransactions.filter((tx) => !isRegistrationTransaction(tx))
   )
 
-  const tokensById = yield* select((state) => tokensByIdSelector(state, getSupportedNetworkIds()))
+  const tokensById = yield* select(tokensByIdSelector)
   const fromToken = tokensById[fromTokenId]
   const toToken = tokensById[toTokenId]
 

--- a/packages/@divvi/mobile/src/tokens/AssetList.tsx
+++ b/packages/@divvi/mobile/src/tokens/AssetList.tsx
@@ -47,7 +47,6 @@ import { sortedTokensWithBalanceOrShowZeroBalanceSelector } from 'src/tokens/sel
 import { TokenBalance } from 'src/tokens/slice'
 import { AssetTabType } from 'src/tokens/types'
 import { getTokenAnalyticsProps } from 'src/tokens/utils'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 
 interface SectionData {
   appName?: string
@@ -94,10 +93,7 @@ export default function AssetList({
   const dispatch = useDispatch()
   const { t } = useTranslation()
 
-  const supportedNetworkIds = getSupportedNetworkIds()
-  const tokens = useSelector((state) =>
-    sortedTokensWithBalanceOrShowZeroBalanceSelector(state, supportedNetworkIds)
-  )
+  const tokens = useSelector(sortedTokensWithBalanceOrShowZeroBalanceSelector)
 
   const hideWalletBalances = useSelector(hideWalletBalancesSelector)
   const isRefreshingBalances = useSelector(balancesLoadingSelector)

--- a/packages/@divvi/mobile/src/tokens/TabWallet.tsx
+++ b/packages/@divvi/mobile/src/tokens/TabWallet.tsx
@@ -31,7 +31,6 @@ import AssetList from 'src/tokens/AssetList'
 import AssetTabBar from 'src/tokens/AssetTabBar'
 import { sortedTokensWithBalanceSelector } from 'src/tokens/selectors'
 import { AssetTabType } from 'src/tokens/types'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.TabWallet>
 
@@ -159,9 +158,7 @@ function TabWallet({ navigation, route }: Props) {
 
   const configuredEmptyState = getAppConfig().experimental?.wallet?.emptyState
 
-  const supportedNetworkIds = getSupportedNetworkIds()
-  const hasTokens =
-    useSelector((state) => sortedTokensWithBalanceSelector(state, supportedNetworkIds)).length > 0
+  const hasTokens = useSelector(sortedTokensWithBalanceSelector).length > 0
 
   return (
     // Transparency issue on Android present when a fragment is used - Nested Animated.View prevents it

--- a/packages/@divvi/mobile/src/tokens/TokenDetails.tsx
+++ b/packages/@divvi/mobile/src/tokens/TokenDetails.tsx
@@ -161,9 +161,7 @@ function PriceInfo({ token }: { token: TokenBalance }) {
 export const useActions = (token: TokenBalance) => {
   const { t } = useTranslation()
   const supportedNetworkIdsForSend = getSupportedNetworkIds()
-  const sendableTokensWithBalance = useSelector((state) =>
-    sortedTokensWithBalanceSelector(state, supportedNetworkIdsForSend)
-  )
+  const sendableTokensWithBalance = useSelector(sortedTokensWithBalanceSelector)
   const { swappableFromTokens } = useSwappableTokens()
   const cashInTokens = useCashInTokens()
   const cashOutTokens = useCashOutTokens()

--- a/packages/@divvi/mobile/src/tokens/TokenImport.tsx
+++ b/packages/@divvi/mobile/src/tokens/TokenImport.tsx
@@ -81,7 +81,7 @@ export default function TokenImportScreen(_: Props) {
     networkShouldBeEditable ? null : supportedNetworkIds[0]
   )
   const walletAddress = useSelector(walletAddressSelector)
-  const supportedTokens = useSelector((state) => tokensByIdSelector(state, supportedNetworkIds))
+  const supportedTokens = useSelector(tokensByIdSelector)
 
   const networkIconByNetworkId = useSelector(networksIconSelector)
 

--- a/packages/@divvi/mobile/src/tokens/hooks.ts
+++ b/packages/@divvi/mobile/src/tokens/hooks.ts
@@ -5,11 +5,11 @@ import { useSelector } from 'src/redux/hooks'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import {
-  cashInTokensByNetworkIdSelector,
-  cashOutTokensByNetworkIdSelector,
-  spendTokensByNetworkIdSelector,
-  swappableFromTokensByNetworkIdSelector,
-  swappableToTokensByNetworkIdSelector,
+  cashInTokensSelector,
+  cashOutTokensSelector,
+  spendTokensSelector,
+  swappableFromTokensSelector,
+  swappableToTokensSelector,
   tokensByAddressSelector,
   tokensByCurrencySelector,
   tokensByIdSelector,
@@ -21,12 +21,9 @@ import {
 } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { convertLocalToTokenAmount, convertTokenToLocalAmount } from 'src/tokens/utils'
-import { NetworkId } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import { deterministicShuffle } from 'src/utils/random'
-import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 
 /**
  * @deprecated use useTokenInfo and select using tokenId
@@ -36,32 +33,29 @@ export function useTokenInfoByAddress(tokenAddress?: string | null) {
   return tokenAddress ? tokens[tokenAddress] : undefined
 }
 
-export function useTokensWithUsdValue(networkIds: NetworkId[]) {
-  return useSelector((state) => tokensWithUsdValueSelector(state, networkIds))
+export function useTokensWithUsdValue() {
+  return useSelector(tokensWithUsdValueSelector)
 }
 
 export function useTotalTokenBalance() {
-  const supportedNetworkIds = getSupportedNetworkIds()
-  return useSelector((state) => totalTokenBalanceSelector(state, supportedNetworkIds))
+  return useSelector(totalTokenBalanceSelector)
 }
 
 export function useTokensWithTokenBalance() {
-  const supportedNetworkIds = getSupportedNetworkIds()
-  return useSelector((state) => tokensWithTokenBalanceSelector(state, supportedNetworkIds))
+  return useSelector(tokensWithTokenBalanceSelector)
 }
 
-export function useTokensInfoUnavailable(networkIds: NetworkId[]) {
-  const totalBalance = useSelector((state) => totalTokenBalanceSelector(state, networkIds))
+export function useTokensInfoUnavailable() {
+  const totalBalance = useSelector(totalTokenBalanceSelector)
   return totalBalance === null
 }
 
 export function useTokensList() {
-  const networkIds = Object.values(networkConfig.networkToNetworkId)
-  return useSelector((state) => tokensListSelector(state, networkIds))
+  return useSelector(tokensListSelector)
 }
 
-export function useTokenPricesAreStale(networkIds: NetworkId[]) {
-  const tokens = useSelector((state) => tokensListSelector(state, networkIds))
+export function useTokenPricesAreStale() {
+  const tokens = useSelector(tokensListSelector)
   // If no tokens then prices cannot be stale
   if (tokens.length === 0) return false
   // Put tokens with priceUsd into an array
@@ -79,16 +73,11 @@ export function useTokenPricesAreStale(networkIds: NetworkId[]) {
 }
 
 export function useSwappableTokens() {
-  const networkIdsForSwap = getSupportedNetworkIds()
   const shouldShuffleTokens = getFeatureGate(StatsigFeatureGates.SHUFFLE_SWAP_TOKENS_ORDER)
 
   const walletAddress = useSelector(walletAddressSelector)
-  const swappableFromTokens = useSelector((state) =>
-    swappableFromTokensByNetworkIdSelector(state, networkIdsForSwap)
-  )
-  const swappableToTokens = useSelector((state) =>
-    swappableToTokensByNetworkIdSelector(state, networkIdsForSwap)
-  )
+  const swappableFromTokens = useSelector(swappableFromTokensSelector)
+  const swappableToTokens = useSelector(swappableToTokensSelector)
 
   if (shouldShuffleTokens && walletAddress) {
     return {
@@ -106,35 +95,24 @@ export function useSwappableTokens() {
 }
 
 export function useCashInTokens() {
-  const networkIdsForCico = getSupportedNetworkIds()
-  return useSelector((state) => cashInTokensByNetworkIdSelector(state, networkIdsForCico))
+  return useSelector(cashInTokensSelector)
 }
 
 export function useCashOutTokens(showZeroBalanceTokens: boolean = false) {
-  const networkIdsForCico = getSupportedNetworkIds()
-  return useSelector((state) =>
-    cashOutTokensByNetworkIdSelector(state, networkIdsForCico, showZeroBalanceTokens)
-  )
+  return useSelector((state) => cashOutTokensSelector(state, showZeroBalanceTokens))
 }
 
 export function useSpendTokens() {
-  const networkIdsForCico = getSupportedNetworkIds()
-  return useSelector((state) => spendTokensByNetworkIdSelector(state, networkIdsForCico))
+  return useSelector(spendTokensSelector)
 }
 
 export function useTokenInfo(tokenId?: string): TokenBalance | undefined {
-  const networkIds = Object.values(networkConfig.networkToNetworkId)
-  const tokens = useSelector((state) =>
-    tokensByIdSelector(state, { networkIds, includePositionTokens: true })
-  )
+  const tokens = useSelector((state) => tokensByIdSelector(state, true))
   return tokenId ? tokens[tokenId] : undefined
 }
 
 export function useTokensInfo(tokenIds: string[]): (TokenBalance | undefined)[] {
-  const networkIds = Object.values(networkConfig.networkToNetworkId)
-  const tokens = useSelector((state) =>
-    tokensByIdSelector(state, { networkIds, includePositionTokens: true })
-  )
+  const tokens = useSelector((state) => tokensByIdSelector(state, true))
   return tokenIds.map((tokenId) => tokens[tokenId])
 }
 

--- a/packages/@divvi/mobile/src/tokens/hooks.ts
+++ b/packages/@divvi/mobile/src/tokens/hooks.ts
@@ -107,12 +107,12 @@ export function useSpendTokens() {
 }
 
 export function useTokenInfo(tokenId?: string): TokenBalance | undefined {
-  const tokens = useSelector((state) => tokensByIdSelector(state, true))
+  const tokens = useSelector((state) => tokensByIdSelector(state, { includePositionTokens: true }))
   return tokenId ? tokens[tokenId] : undefined
 }
 
 export function useTokensInfo(tokenIds: string[]): (TokenBalance | undefined)[] {
-  const tokens = useSelector((state) => tokensByIdSelector(state, true))
+  const tokens = useSelector((state) => tokensByIdSelector(state, { includePositionTokens: true }))
   return tokenIds.map((tokenId) => tokens[tokenId])
 }
 

--- a/packages/@divvi/mobile/src/tokens/saga.test.ts
+++ b/packages/@divvi/mobile/src/tokens/saga.test.ts
@@ -171,7 +171,7 @@ describe(fetchTokenBalancesSaga, () => {
 
     await expectSaga(fetchTokenBalancesSaga)
       .provide([
-        [select(importedTokensSelector, supportedNetworks), []],
+        [select(importedTokensSelector), []],
         [select(networksIconSelector), {}],
         [call(getTokensInfo, supportedNetworks), mockBlockchainApiTokenInfo],
         [select(walletAddressSelector), mockAccount],
@@ -199,7 +199,7 @@ describe(fetchTokenBalancesSaga, () => {
 
     await expectSaga(fetchTokenBalancesSaga)
       .provide([
-        [select(importedTokensSelector, supportedNetworks), []],
+        [select(importedTokensSelector), []],
         [select(networksIconSelector), {}],
         [call(getTokensInfo, supportedNetworks), mockBlockchainApiTokenInfo],
         [select(walletAddressSelector), mockAccount],
@@ -239,7 +239,7 @@ describe(fetchTokenBalancesSaga, () => {
     await expectSaga(fetchTokenBalancesSaga)
       .provide([
         [call(getTokensInfo, supportedNetworks), mockBlockchainApiTokenInfo],
-        [select(importedTokensSelector, supportedNetworks), importedTokens],
+        [select(importedTokensSelector), importedTokens],
         [
           select(networksIconSelector),
           {
@@ -458,7 +458,7 @@ describe('watchAccountFundedOrLiquidated', () => {
     await expectSaga(watchAccountFundedOrLiquidated)
       .provide([
         [
-          select(lastKnownTokenBalancesSelector, [NetworkId['celo-alfajores']]),
+          select(lastKnownTokenBalancesSelector),
           dynamic(balances(new BigNumber(0), new BigNumber(10))),
         ],
       ])
@@ -475,7 +475,7 @@ describe('watchAccountFundedOrLiquidated', () => {
     await expectSaga(watchAccountFundedOrLiquidated)
       .provide([
         [
-          select(lastKnownTokenBalancesSelector, [NetworkId['celo-alfajores']]),
+          select(lastKnownTokenBalancesSelector),
           dynamic(balances(new BigNumber(10), new BigNumber(0))),
         ],
       ])
@@ -491,10 +491,7 @@ describe('watchAccountFundedOrLiquidated', () => {
     jest.mocked(getSupportedNetworkIds).mockReturnValue([NetworkId['celo-alfajores']])
     await expectSaga(watchAccountFundedOrLiquidated)
       .provide([
-        [
-          select(lastKnownTokenBalancesSelector, [NetworkId['celo-alfajores']]),
-          dynamic(balances(null, new BigNumber(10))),
-        ],
+        [select(lastKnownTokenBalancesSelector), dynamic(balances(null, new BigNumber(10)))],
       ])
       .dispatch({ type: 'TEST_ACTION_TYPE' })
       .dispatch({ type: 'TEST_ACTION_TYPE' })

--- a/packages/@divvi/mobile/src/tokens/saga.ts
+++ b/packages/@divvi/mobile/src/tokens/saga.ts
@@ -146,7 +146,9 @@ export function tokenAmountInSmallestUnit(amount: BigNumber, decimals: number): 
 }
 
 export function* getTokenInfo(tokenId: string) {
-  const tokens = yield* select((state) => tokensByIdSelector(state, true))
+  const tokens = yield* select((state) =>
+    tokensByIdSelector(state, { includePositionTokens: true })
+  )
   return tokens[tokenId]
 }
 

--- a/packages/@divvi/mobile/src/tokens/saga.ts
+++ b/packages/@divvi/mobile/src/tokens/saga.ts
@@ -87,7 +87,7 @@ export function* fetchTokenBalancesSaga() {
     SentryTransactionHub.startTransaction(SentryTransaction.fetch_balances)
 
     const supportedNetworks = getSupportedNetworkIds()
-    const importedTokens = yield* select(importedTokensSelector, supportedNetworks)
+    const importedTokens = yield* select(importedTokensSelector)
     const networkIconByNetworkId = yield* select(networksIconSelector)
 
     const supportedTokens = yield* call(getTokensInfo, supportedNetworks)
@@ -146,10 +146,7 @@ export function tokenAmountInSmallestUnit(amount: BigNumber, decimals: number): 
 }
 
 export function* getTokenInfo(tokenId: string) {
-  const networkIds = Object.values(networkConfig.networkToNetworkId)
-  const tokens = yield* select((state) =>
-    tokensByIdSelector(state, { networkIds, includePositionTokens: true })
-  )
+  const tokens = yield* select((state) => tokensByIdSelector(state, true))
   return tokens[tokenId]
 }
 
@@ -159,10 +156,8 @@ export function* watchAccountFundedOrLiquidated() {
     // we reset the usd value of all token balances to 0 if the exchange rate is
     // stale, so it is okay to use stale token prices to monitor the account
     // funded / liquidated status in this case
-    const supportedNetworkIds = getSupportedNetworkIds()
     const tokenBalance: ReturnType<typeof lastKnownTokenBalancesSelector> = yield* select(
-      lastKnownTokenBalancesSelector,
-      supportedNetworkIds
+      lastKnownTokenBalancesSelector
     )
 
     if (tokenBalance !== null && tokenBalance !== prevTokenBalance) {

--- a/packages/@divvi/mobile/src/tokens/utils.ts
+++ b/packages/@divvi/mobile/src/tokens/utils.ts
@@ -8,7 +8,6 @@ import { Network, NetworkId } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS, ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 import networkConfig from 'src/web3/networkConfig'
-import { getSupportedNetworkIds } from 'src/web3/utils'
 import { TokenBalance } from './slice'
 
 export function getHigherBalanceCurrency(
@@ -164,11 +163,6 @@ export function getTokenId(networkId: NetworkId, tokenAddress?: string): string 
     return `${networkId}:native`
   }
   return `${networkId}:${tokenAddress}`
-}
-
-export type GetSupportedNetworkIdsForSend = typeof getSupportedNetworkIdsForSend
-export function getSupportedNetworkIdsForSend(): NetworkId[] {
-  return getSupportedNetworkIds()
 }
 
 export function getTokenAnalyticsProps(token: TokenBalance): TokenProperties {

--- a/packages/@divvi/mobile/src/transactions/feed/queryHelper.ts
+++ b/packages/@divvi/mobile/src/transactions/feed/queryHelper.ts
@@ -449,7 +449,7 @@ async function queryTransactionsFeed({
 }
 
 function trackCrossChainSwapSuccess(tx: TokenExchange) {
-  const tokensById = tokensByIdSelector(store.getState(), getSupportedNetworkIds())
+  const tokensById = tokensByIdSelector(store.getState())
 
   const toTokenPrice = tokensById[tx.inAmount.tokenId]?.priceUsd
   const fromTokenPrice = tokensById[tx.outAmount.tokenId]?.priceUsd

--- a/packages/@divvi/mobile/src/transactions/saga.ts
+++ b/packages/@divvi/mobile/src/transactions/saga.ts
@@ -189,7 +189,7 @@ function* handleTransactionReceiptReceived({
   feeCurrencyId?: string
   overrideStatus?: TransactionStatus
 }) {
-  const tokensById = yield* select((state) => tokensByIdSelector(state, [networkId]))
+  const tokensById = yield* select(tokensByIdSelector)
 
   const feeTokenInfo = feeCurrencyId && tokensById[feeCurrencyId]
 
@@ -251,7 +251,7 @@ function trackCompletionOfCrossChainTxs(
   state: RootState,
   transactions: (TokenExchange | DepositOrWithdraw)[]
 ) {
-  const tokensById = tokensByIdSelector(state, getSupportedNetworkIds())
+  const tokensById = tokensByIdSelector(state)
 
   for (const tx of transactions) {
     const networkFee = tx.fees.find((fee) => fee.type === FeeType.SecurityFee)

--- a/packages/@divvi/mobile/src/viem/saga.ts
+++ b/packages/@divvi/mobile/src/viem/saga.ts
@@ -121,7 +121,7 @@ export function* sendPreparedTransactions(
       hash
     )
 
-    const tokensById = yield* select((state) => tokensByIdSelector(state, [networkId]))
+    const tokensById = yield* select(tokensByIdSelector)
     const feeCurrencyId = getFeeCurrencyToken([preparedTransaction], networkId, tokensById)?.tokenId
 
     const standByTx = createBaseStandbyTransaction(hash, feeCurrencyId)

--- a/packages/@divvi/mobile/src/walletConnect/screens/EstimatedNetworkFee.tsx
+++ b/packages/@divvi/mobile/src/walletConnect/screens/EstimatedNetworkFee.tsx
@@ -57,7 +57,7 @@ function getNetworkFee(
 export default function EstimatedNetworkFee({ isLoading, networkId, transactions }: Props) {
   const { t } = useTranslation()
 
-  const tokensById = useSelector((state) => tokensByIdSelector(state, [networkId]))
+  const tokensById = useSelector(tokensByIdSelector)
   const networkFee = getNetworkFee(transactions, networkId, tokensById)
 
   const networkName = NETWORK_NAMES[networkId]


### PR DESCRIPTION
### Description

Now that we've dropped per feature network id configuration, the token selectors no longer need to take networkIds to filter out tokens. 

The primary change for this PR is in `src/tokens/selectors.ts`. Specifically the top level selector now filters tokens using the `getSupportedNetworkIds` util instead of the networkIds param.

Others are just changes in selector usages to drop the param. Some usages were only passing a single network Id, but those were then just extracting required tokens by tokenId, so we don't need the filtering by network Id there. Others usages where filtering was required, it is just done locally after getting all tokens.

More cleanup, like hooks which now just wrap a useSelector, can be done in a follow up

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
