### PR TITLE
docs: add prebuild step

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,6 +30,11 @@ cd my-app
 yarn install
 ```
 
+3. Generate native source code:
+```bash
+yarn prebuild
+```
+
 ## Setting Up Your Development Environment
 
 Before running your app, you'll need to set up your development environment. While we use Expo's build tools, Divvi Mobile requires a native development environment (it cannot run in Expo Go).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,7 @@ yarn install
 ```
 
 3. Generate native source code:
+
 ```bash
 yarn prebuild
 ```


### PR DESCRIPTION
### Description

Adds the prebuild step required for quick start runs to docs.

### Test plan

N/A

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
