### PR TITLE
feat: Add (de)serialization for PossibleTransactionResult and apply it to SendConfirmation

### DIFF
--- a/packages/@divvi/mobile/src/navigator/types.tsx
+++ b/packages/@divvi/mobile/src/navigator/types.tsx
@@ -10,14 +10,16 @@ import { KeylessBackupFlow, KeylessBackupOrigin } from 'src/keylessBackup/types'
 import { Screens } from 'src/navigator/Screens'
 import { Nft } from 'src/nfts/types'
 import { EarnPosition } from 'src/positions/types'
-import type { PreparedTransactionsResult } from 'src/public'
 import { Recipient } from 'src/recipients/recipient'
 import { QrCode, TransactionDataInput } from 'src/send/types'
 import { AssetTabType } from 'src/tokens/types'
 import { NetworkId, TokenTransaction, TokenTransfer } from 'src/transactions/types'
 import { Countries } from 'src/utils/Countries'
 import { Currency } from 'src/utils/currencies'
-import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
+import {
+  SerializableTransactionRequest,
+  type SerializablePreparedTransactionsPossible,
+} from 'src/viem/preparedTransactionSerialization'
 import { ActionRequestProps } from 'src/walletConnect/screens/ActionRequest'
 import { SessionRequestProps } from 'src/walletConnect/screens/SessionRequest'
 import { WalletConnectRequestType } from 'src/walletConnect/types'
@@ -34,7 +36,7 @@ interface SendConfirmationParams {
   origin: SendOrigin
   transactionData: TransactionDataInput
   isFromScan: boolean
-  prepareTransactionsResult?: PreparedTransactionsResult
+  prepareTransactionsResult?: SerializablePreparedTransactionsPossible
 }
 
 type SendEnterAmountParams = {

--- a/packages/@divvi/mobile/src/send/SendConfirmation.test.tsx
+++ b/packages/@divvi/mobile/src/send/SendConfirmation.test.tsx
@@ -11,7 +11,10 @@ import SendConfirmation from 'src/send/SendConfirmation'
 import { sendPayment } from 'src/send/actions'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
-import { getSerializablePreparedTransaction } from 'src/viem/preparedTransactionSerialization'
+import {
+  getSerializablePossibleTransaction,
+  getSerializablePreparedTransaction,
+} from 'src/viem/preparedTransactionSerialization'
 import { RecursivePartial, createMockStore, getMockStackScreenProps } from 'test/utils'
 import {
   mockAccount,
@@ -68,7 +71,9 @@ const mockBaseScreenProps = {
 
 const mockSendConfirmationProps = getMockStackScreenProps(Screens.SendConfirmation, {
   ...mockBaseScreenProps,
-  prepareTransactionsResult: mockPrepareTransactionsResultPossible,
+  prepareTransactionsResult: getSerializablePossibleTransaction(
+    mockPrepareTransactionsResultPossible
+  ),
 })
 
 type ScreenProps = NativeStackScreenProps<StackParamList, Screens.SendConfirmation>

--- a/packages/@divvi/mobile/src/send/SendConfirmation.test.tsx
+++ b/packages/@divvi/mobile/src/send/SendConfirmation.test.tsx
@@ -12,8 +12,8 @@ import { sendPayment } from 'src/send/actions'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import {
-  getSerializablePossibleTransaction,
   getSerializablePreparedTransaction,
+  getSerializablePreparedTransactionsPossible,
 } from 'src/viem/preparedTransactionSerialization'
 import { RecursivePartial, createMockStore, getMockStackScreenProps } from 'test/utils'
 import {
@@ -71,7 +71,7 @@ const mockBaseScreenProps = {
 
 const mockSendConfirmationProps = getMockStackScreenProps(Screens.SendConfirmation, {
   ...mockBaseScreenProps,
-  prepareTransactionsResult: getSerializablePossibleTransaction(
+  prepareTransactionsResult: getSerializablePreparedTransactionsPossible(
     mockPrepareTransactionsResultPossible
   ),
 })

--- a/packages/@divvi/mobile/src/send/SendConfirmation.tsx
+++ b/packages/@divvi/mobile/src/send/SendConfirmation.tsx
@@ -37,7 +37,7 @@ import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import Logger from 'src/utils/Logger'
 import { getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
 import {
-  getDeserializedPossibleTransaction,
+  getPreparedTransactionsPossible,
   getSerializablePreparedTransaction,
 } from 'src/viem/preparedTransactionSerialization'
 import { walletAddressSelector } from 'src/web3/selectors'
@@ -54,7 +54,7 @@ function usePreparedTransaction(params: Props['route']['params']) {
 
   const deserializedTx = useMemo(() => {
     return params.prepareTransactionsResult
-      ? getDeserializedPossibleTransaction(params.prepareTransactionsResult)
+      ? getPreparedTransactionsPossible(params.prepareTransactionsResult)
       : null
   }, [params.prepareTransactionsResult])
 

--- a/packages/@divvi/mobile/src/send/SendConfirmation.tsx
+++ b/packages/@divvi/mobile/src/send/SendConfirmation.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { showError } from 'src/alert/actions'
 import AppAnalytics from 'src/analytics/AppAnalytics'
@@ -36,7 +36,10 @@ import { useAmountAsUsd, useTokenInfo, useTokenToLocalAmount } from 'src/tokens/
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import Logger from 'src/utils/Logger'
 import { getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
-import { getSerializablePreparedTransaction } from 'src/viem/preparedTransactionSerialization'
+import {
+  getDeserializedPossibleTransaction,
+  getSerializablePreparedTransaction,
+} from 'src/viem/preparedTransactionSerialization'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.SendConfirmation>
@@ -45,22 +48,37 @@ const TAG = 'send/SendConfirmation'
 
 export const sendConfirmationScreenNavOptions = noHeader
 
-export default function SendConfirmation(props: Props) {
+function usePreparedTransaction(params: Props['route']['params']) {
+  const { prepareTransactionsResult, refreshPreparedTransactions, prepareTransactionLoading } =
+    usePrepareSendTransactions()
+
+  const deserializedTx = useMemo(() => {
+    return params.prepareTransactionsResult
+      ? getDeserializedPossibleTransaction(params.prepareTransactionsResult)
+      : null
+  }, [params.prepareTransactionsResult])
+
+  return {
+    prepareTransactionsResult: deserializedTx ?? prepareTransactionsResult,
+    prepareTransactionLoading: deserializedTx ? false : prepareTransactionLoading,
+    refreshPreparedTransactions,
+  }
+}
+
+export default function SendConfirmation({ route: { params } }: Props) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const feesBottomSheetRef = useRef<BottomSheetModalRefType>(null)
   const totalBottomSheetRef = useRef<BottomSheetModalRefType>(null)
+  const openedViaDeeplink = !params.prepareTransactionsResult
 
   const {
     origin,
     transactionData: { recipient, tokenAmount, tokenAddress, tokenId },
-  } = props.route.params
+  } = params
 
   const { prepareTransactionsResult, refreshPreparedTransactions, prepareTransactionLoading } =
-    usePrepareSendTransactions()
-
-  const openedViaDeeplink = !props.route.params.prepareTransactionsResult
-  const preparedResult = props.route.params.prepareTransactionsResult ?? prepareTransactionsResult
+    usePreparedTransaction(params)
 
   const tokenInfo = useTokenInfo(tokenId)
   const isSending = useSelector(isSendingSelector)
@@ -101,11 +119,14 @@ export default function SendConfirmation(props: Props) {
     })
   }, [tokenInfo, tokenAmount, recipient, walletAddress, feeCurrencies, openedViaDeeplink])
 
-  const disableSend = isSending || !preparedResult || preparedResult.type !== 'possible'
+  const disableSend =
+    isSending || !prepareTransactionsResult || prepareTransactionsResult.type !== 'possible'
 
   const onSend = () => {
     const preparedTransaction =
-      preparedResult && preparedResult.type === 'possible' && preparedResult.transactions[0]
+      prepareTransactionsResult &&
+      prepareTransactionsResult.type === 'possible' &&
+      prepareTransactionsResult.transactions[0]
     if (!preparedTransaction) {
       // This should never happen because the confirm button is disabled if this happens.
       dispatch(showError(ErrorMessages.SEND_PAYMENT_FAILED))
@@ -115,7 +136,7 @@ export default function SendConfirmation(props: Props) {
     AppAnalytics.track(SendEvents.send_confirm_send, {
       origin,
       recipientType: recipient.recipientType,
-      isScan: props.route.params.isFromScan,
+      isScan: params.isFromScan,
       localCurrency: localCurrencyCode,
       usdAmount: usdAmount?.toString() ?? null,
       localCurrencyAmount: localAmount?.toString() ?? null,

--- a/packages/@divvi/mobile/src/send/SendEnterAmount.test.tsx
+++ b/packages/@divvi/mobile/src/send/SendEnterAmount.test.tsx
@@ -10,6 +10,7 @@ import { Screens } from 'src/navigator/Screens'
 import { RecipientType } from 'src/recipients/recipient'
 import SendEnterAmount from 'src/send/SendEnterAmount'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
+import { getSerializablePossibleTransaction } from 'src/viem/preparedTransactionSerialization'
 import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore, mockStoreBalancesToTokenBalances } from 'test/utils'
@@ -167,7 +168,9 @@ describe('SendEnterAmount', () => {
     expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmation, {
       origin: params.origin,
       isFromScan: params.isFromScan,
-      prepareTransactionsResult: mockedPrepareTransactions.prepareTransactionsResult,
+      prepareTransactionsResult: getSerializablePossibleTransaction(
+        mockedPrepareTransactions.prepareTransactionsResult
+      ),
       transactionData: {
         tokenId: mockCeloTokenId,
         recipient: params.recipient,

--- a/packages/@divvi/mobile/src/send/SendEnterAmount.test.tsx
+++ b/packages/@divvi/mobile/src/send/SendEnterAmount.test.tsx
@@ -10,7 +10,7 @@ import { Screens } from 'src/navigator/Screens'
 import { RecipientType } from 'src/recipients/recipient'
 import SendEnterAmount from 'src/send/SendEnterAmount'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
-import { getSerializablePossibleTransaction } from 'src/viem/preparedTransactionSerialization'
+import { getSerializablePreparedTransactionsPossible } from 'src/viem/preparedTransactionSerialization'
 import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore, mockStoreBalancesToTokenBalances } from 'test/utils'
@@ -168,7 +168,7 @@ describe('SendEnterAmount', () => {
     expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmation, {
       origin: params.origin,
       isFromScan: params.isFromScan,
-      prepareTransactionsResult: getSerializablePossibleTransaction(
+      prepareTransactionsResult: getSerializablePreparedTransactionsPossible(
         mockedPrepareTransactions.prepareTransactionsResult
       ),
       transactionData: {

--- a/packages/@divvi/mobile/src/send/SendEnterAmount.tsx
+++ b/packages/@divvi/mobile/src/send/SendEnterAmount.tsx
@@ -14,6 +14,7 @@ import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import { sortedTokensWithBalanceOrShowZeroBalanceSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
+import { getSerializablePossibleTransaction } from 'src/viem/preparedTransactionSerialization'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.SendEnterAmount>
@@ -46,7 +47,7 @@ function SendEnterAmount({ route }: Props) {
     navigate(Screens.SendConfirmation, {
       origin,
       isFromScan,
-      prepareTransactionsResult,
+      prepareTransactionsResult: getSerializablePossibleTransaction(prepareTransactionsResult),
       transactionData: {
         tokenId: token.tokenId,
         recipient,

--- a/packages/@divvi/mobile/src/send/SendEnterAmount.tsx
+++ b/packages/@divvi/mobile/src/send/SendEnterAmount.tsx
@@ -14,7 +14,7 @@ import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import { sortedTokensWithBalanceOrShowZeroBalanceSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
-import { getSerializablePossibleTransaction } from 'src/viem/preparedTransactionSerialization'
+import { getSerializablePreparedTransactionsPossible } from 'src/viem/preparedTransactionSerialization'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.SendEnterAmount>
@@ -47,7 +47,8 @@ function SendEnterAmount({ route }: Props) {
     navigate(Screens.SendConfirmation, {
       origin,
       isFromScan,
-      prepareTransactionsResult: getSerializablePossibleTransaction(prepareTransactionsResult),
+      prepareTransactionsResult:
+        getSerializablePreparedTransactionsPossible(prepareTransactionsResult),
       transactionData: {
         tokenId: token.tokenId,
         recipient,

--- a/packages/@divvi/mobile/src/tokens/TokenDetails.test.tsx
+++ b/packages/@divvi/mobile/src/tokens/TokenDetails.test.tsx
@@ -124,7 +124,7 @@ describe('TokenDetails', () => {
             historicalPricesUsd: {
               lastDay: {
                 at: Date.now() - 2 * ONE_DAY_IN_MILLIS,
-                price: 1,
+                price: '1',
               },
             },
           },
@@ -151,7 +151,7 @@ describe('TokenDetails', () => {
             historicalPricesUsd: {
               lastDay: {
                 at: Date.now() - ONE_DAY_IN_MILLIS,
-                price: 1,
+                price: '1',
               },
             },
           },

--- a/packages/@divvi/mobile/src/tokens/slice.ts
+++ b/packages/@divvi/mobile/src/tokens/slice.ts
@@ -58,6 +58,11 @@ export interface TokenBalance extends BaseToken {
   historicalPricesUsd?: HistoricalPricesUsd
 }
 
+export type SerializedBigNumber<T> = T extends BigNumber ? string : T
+export type SerializedTokenBalance = BaseToken & {
+  [K in Exclude<keyof TokenBalance, keyof BaseToken>]: SerializedBigNumber<TokenBalance[K]>
+}
+
 // The "WithAddress" suffixed types are legacy types, for places in the wallet
 // that require an address to be present. Many are deprecated because in most places, we should
 // be able to handle tokens without addresses the same way (just use tokenId instead if you need a token identifier).

--- a/packages/@divvi/mobile/src/tokens/slice.ts
+++ b/packages/@divvi/mobile/src/tokens/slice.ts
@@ -58,7 +58,7 @@ export interface TokenBalance extends BaseToken {
   historicalPricesUsd?: HistoricalPricesUsd
 }
 
-export type SerializedBigNumber<T> = T extends BigNumber ? string : T
+type SerializedBigNumber<T> = T extends BigNumber ? string : T
 export type SerializedTokenBalance = BaseToken & {
   [K in Exclude<keyof TokenBalance, keyof BaseToken>]: SerializedBigNumber<TokenBalance[K]>
 }

--- a/packages/@divvi/mobile/src/tokens/slice.ts
+++ b/packages/@divvi/mobile/src/tokens/slice.ts
@@ -35,7 +35,7 @@ export interface BaseToken {
 
 interface HistoricalPricesUsd {
   lastDay: {
-    price: BigNumber.Value
+    price: string
     at: number
   }
 }
@@ -59,8 +59,8 @@ export interface TokenBalance extends BaseToken {
 }
 
 type SerializedBigNumber<T> = T extends BigNumber ? string : T
-export type SerializedTokenBalance = BaseToken & {
-  [K in Exclude<keyof TokenBalance, keyof BaseToken>]: SerializedBigNumber<TokenBalance[K]>
+export type SerializedTokenBalance = {
+  [K in keyof TokenBalance]: SerializedBigNumber<TokenBalance[K]>
 }
 
 // The "WithAddress" suffixed types are legacy types, for places in the wallet

--- a/packages/@divvi/mobile/src/tokens/utils.test.tsx
+++ b/packages/@divvi/mobile/src/tokens/utils.test.tsx
@@ -4,9 +4,9 @@ import { TokenBalance } from 'src/tokens/slice'
 import {
   convertLocalToTokenAmount,
   convertTokenToLocalAmount,
-  getDeserializedTokenBalance,
   getHigherBalanceCurrency,
   getSerializableTokenBalance,
+  getTokenBalance,
   getTokenId,
   isHistoricalPriceUpdated,
   sortFirstStableThenCeloThenOthersByUsdBalance,
@@ -242,7 +242,7 @@ describe(isHistoricalPriceUpdated, () => {
         historicalPricesUsd: {
           lastDay: {
             at: Date.now() - ONE_DAY_IN_MILLIS - 2 * ONE_HOUR_IN_MILLIS,
-            price: new BigNumber(0),
+            price: '0',
           },
         },
       })
@@ -256,7 +256,7 @@ describe(isHistoricalPriceUpdated, () => {
         historicalPricesUsd: {
           lastDay: {
             at: Date.now() - ONE_DAY_IN_MILLIS,
-            price: new BigNumber(0),
+            price: '0',
           },
         },
       })
@@ -270,7 +270,7 @@ describe(isHistoricalPriceUpdated, () => {
         historicalPricesUsd: {
           lastDay: {
             at: Date.now() - ONE_DAY_IN_MILLIS - ONE_HOUR_IN_MILLIS / 2,
-            price: new BigNumber(0),
+            price: '0',
           },
         },
       })
@@ -284,7 +284,7 @@ describe(isHistoricalPriceUpdated, () => {
         historicalPricesUsd: {
           lastDay: {
             at: Date.now() - ONE_DAY_IN_MILLIS + ONE_HOUR_IN_MILLIS / 2,
-            price: new BigNumber(0),
+            price: '0',
           },
         },
       })
@@ -303,9 +303,9 @@ describe(getSerializableTokenBalance, () => {
   })
 })
 
-describe(getDeserializedTokenBalance, () => {
+describe(getTokenBalance, () => {
   it('deserializes TokenBalance correctly', () => {
-    const deserialized = getDeserializedTokenBalance({
+    const deserialized = getTokenBalance({
       address: mockTokenBalance.address,
       tokenId: mockTokenBalance.tokenId,
       networkId: mockTokenBalance.networkId,

--- a/packages/@divvi/mobile/src/tokens/utils.test.tsx
+++ b/packages/@divvi/mobile/src/tokens/utils.test.tsx
@@ -4,7 +4,9 @@ import { TokenBalance } from 'src/tokens/slice'
 import {
   convertLocalToTokenAmount,
   convertTokenToLocalAmount,
+  getDeserializedTokenBalance,
   getHigherBalanceCurrency,
+  getSerializableTokenBalance,
   getTokenId,
   isHistoricalPriceUpdated,
   sortFirstStableThenCeloThenOthersByUsdBalance,
@@ -14,6 +16,13 @@ import { Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS, ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 import networkConfig from 'src/web3/networkConfig'
 import { mockPoofTokenId, mockTokenBalances } from 'test/values'
+
+const mockTokenBalance: TokenBalance = {
+  ...mockTokenBalances[mockPoofTokenId],
+  balance: new BigNumber(0),
+  lastKnownPriceUsd: new BigNumber(0),
+  priceUsd: new BigNumber(0),
+}
 
 describe(getHigherBalanceCurrency, () => {
   const tokens = {
@@ -222,13 +231,6 @@ describe(getTokenId, () => {
 })
 
 describe(isHistoricalPriceUpdated, () => {
-  const mockTokenBalance: TokenBalance = {
-    ...mockTokenBalances[mockPoofTokenId],
-    balance: new BigNumber(0),
-    lastKnownPriceUsd: new BigNumber(0),
-    priceUsd: new BigNumber(0),
-  }
-
   it('returns false if no historical price is set', () => {
     expect(isHistoricalPriceUpdated(mockTokenBalance)).toEqual(false)
   })
@@ -287,5 +289,42 @@ describe(isHistoricalPriceUpdated, () => {
         },
       })
     ).toEqual(true)
+  })
+})
+
+describe(getSerializableTokenBalance, () => {
+  it('serializes TokenBalance correctly', () => {
+    const serialized = getSerializableTokenBalance(mockTokenBalance)
+
+    expect(serialized.balance).toBe(mockTokenBalance.balance.toString())
+    expect(serialized.priceUsd).toBe(mockTokenBalance.priceUsd?.toString())
+    expect(serialized.lastKnownPriceUsd).toBe(mockTokenBalance.lastKnownPriceUsd?.toString())
+    expect(serialized.historicalPricesUsd).toBeUndefined()
+  })
+})
+
+describe(getDeserializedTokenBalance, () => {
+  it('deserializes TokenBalance correctly', () => {
+    const deserialized = getDeserializedTokenBalance({
+      address: mockTokenBalance.address,
+      tokenId: mockTokenBalance.tokenId,
+      networkId: mockTokenBalance.networkId,
+      symbol: mockTokenBalance.symbol,
+      imageUrl: mockTokenBalance.imageUrl,
+      name: mockTokenBalance.name,
+      decimals: mockTokenBalance.decimals,
+      priceFetchedAt: mockTokenBalance.priceFetchedAt,
+      balance: mockTokenBalance.balance.toString(),
+      priceUsd: mockTokenBalance.priceUsd!.toString(),
+      lastKnownPriceUsd: mockTokenBalance.lastKnownPriceUsd!.toString(),
+      historicalPricesUsd: undefined,
+    })
+
+    expect(deserialized.balance.isEqualTo(mockTokenBalance.balance)).toBe(true)
+    expect(deserialized.priceUsd?.isEqualTo(mockTokenBalance.priceUsd!)).toBe(true)
+    expect(deserialized.lastKnownPriceUsd?.isEqualTo(mockTokenBalance.lastKnownPriceUsd!)).toBe(
+      true
+    )
+    expect(deserialized.historicalPricesUsd).toBeUndefined()
   })
 })

--- a/packages/@divvi/mobile/src/tokens/utils.ts
+++ b/packages/@divvi/mobile/src/tokens/utils.ts
@@ -8,7 +8,7 @@ import { Network, NetworkId } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS, ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 import networkConfig from 'src/web3/networkConfig'
-import { TokenBalance } from './slice'
+import type { SerializedTokenBalance, TokenBalance } from './slice'
 
 export function getHigherBalanceCurrency(
   currencies: Currency[],
@@ -193,4 +193,29 @@ export function isHistoricalPriceUpdated(token: TokenBalance) {
 
 export function isFeeCurrency(token: TokenBalance | undefined): token is TokenBalance {
   return token?.isNative || !!token?.isFeeCurrency || !!token?.feeCurrencyAdapterAddress
+}
+
+export function getSerializableTokenBalance(tokenInfo: TokenBalance): SerializedTokenBalance {
+  const { balance, priceUsd, lastKnownPriceUsd, historicalPricesUsd, ...baseToken } = tokenInfo
+
+  return {
+    ...baseToken,
+    historicalPricesUsd,
+    balance: balance.toString(),
+    priceUsd: priceUsd?.toString() ?? null,
+    lastKnownPriceUsd: lastKnownPriceUsd?.toString() ?? null,
+  }
+}
+
+export function getDeserializedTokenBalance(
+  serializedTokenInfo: SerializedTokenBalance
+): TokenBalance {
+  const { balance, priceUsd, lastKnownPriceUsd, ...baseToken } = serializedTokenInfo
+
+  return {
+    ...baseToken,
+    balance: new BigNumber(balance),
+    priceUsd: priceUsd === null ? null : new BigNumber(priceUsd),
+    lastKnownPriceUsd: lastKnownPriceUsd === null ? null : new BigNumber(lastKnownPriceUsd),
+  }
 }

--- a/packages/@divvi/mobile/src/tokens/utils.ts
+++ b/packages/@divvi/mobile/src/tokens/utils.ts
@@ -196,20 +196,17 @@ export function isFeeCurrency(token: TokenBalance | undefined): token is TokenBa
 }
 
 export function getSerializableTokenBalance(tokenInfo: TokenBalance): SerializedTokenBalance {
-  const { balance, priceUsd, lastKnownPriceUsd, historicalPricesUsd, ...baseToken } = tokenInfo
+  const { balance, priceUsd, lastKnownPriceUsd, ...baseToken } = tokenInfo
 
   return {
     ...baseToken,
-    historicalPricesUsd,
     balance: balance.toString(),
     priceUsd: priceUsd?.toString() ?? null,
     lastKnownPriceUsd: lastKnownPriceUsd?.toString() ?? null,
   }
 }
 
-export function getDeserializedTokenBalance(
-  serializedTokenInfo: SerializedTokenBalance
-): TokenBalance {
+export function getTokenBalance(serializedTokenInfo: SerializedTokenBalance): TokenBalance {
   const { balance, priceUsd, lastKnownPriceUsd, ...baseToken } = serializedTokenInfo
 
   return {

--- a/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.test.ts
+++ b/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.test.ts
@@ -5,8 +5,8 @@ import { NetworkId } from 'src/transactions/types'
 import {
   getDeserializedPossibleTransaction,
   getPreparedTransactions,
-  getSerializablePossibleTransaction,
   getSerializablePreparedTransactions,
+  getSerializablePreparedTransactionsPossible,
   type SerializablePreparedTransactionsPossible,
 } from 'src/viem/preparedTransactionSerialization'
 
@@ -122,7 +122,7 @@ describe(getPreparedTransactions, () => {
   })
 })
 
-describe(getSerializablePossibleTransaction, () => {
+describe(getSerializablePreparedTransactionsPossible, () => {
   const possibleTransaction: PreparedTransactionsPossible = {
     type: 'possible',
     transactions: [
@@ -138,7 +138,7 @@ describe(getSerializablePossibleTransaction, () => {
     feeCurrency: mockFeeCurrency,
   }
   it('should serialize possible transaction by converting bigint fields to strings', () => {
-    const serialized = getSerializablePossibleTransaction(possibleTransaction)
+    const serialized = getSerializablePreparedTransactionsPossible(possibleTransaction)
     expect(serialized).toEqual({
       type: 'possible',
       transactions: [

--- a/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.test.ts
+++ b/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.test.ts
@@ -1,7 +1,28 @@
+import BigNumber from 'bignumber.js'
+import type { PreparedTransactionsPossible } from 'src/public'
+import { getDeserializedTokenBalance, getSerializableTokenBalance } from 'src/tokens/utils'
+import { NetworkId } from 'src/transactions/types'
 import {
+  getDeserializedPossibleTransaction,
   getPreparedTransactions,
+  getSerializablePossibleTransaction,
   getSerializablePreparedTransactions,
+  type SerializablePreparedTransactionsPossible,
 } from 'src/viem/preparedTransactionSerialization'
+
+const mockFeeCurrency = {
+  address: '0xfee2',
+  balance: new BigNumber(70), // 70k units, 70.0 decimals
+  decimals: 3,
+  priceUsd: null,
+  lastKnownPriceUsd: null,
+  tokenId: 'celo-mainnet:0xfee2',
+  symbol: 'FEE2',
+  name: 'Fee token 2',
+  networkId: NetworkId['celo-mainnet'],
+  isNative: false, // means we add 50_000 units / 50.0 decimal padding for gas
+  isFeeCurrency: true,
+}
 
 describe(getSerializablePreparedTransactions, () => {
   it('should turn bigints into strings for known bigint keys', () => {
@@ -98,5 +119,74 @@ describe(getPreparedTransactions, () => {
         gas: BigInt(456),
       },
     ])
+  })
+})
+
+describe(getSerializablePossibleTransaction, () => {
+  const possibleTransaction: PreparedTransactionsPossible = {
+    type: 'possible',
+    transactions: [
+      {
+        from: '0x123',
+        to: '0x456',
+        value: BigInt(123),
+        gas: BigInt(456),
+        maxFeePerGas: BigInt(789),
+        maxPriorityFeePerGas: BigInt(1011),
+      },
+    ],
+    feeCurrency: mockFeeCurrency,
+  }
+  it('should serialize possible transaction by converting bigint fields to strings', () => {
+    const serialized = getSerializablePossibleTransaction(possibleTransaction)
+    expect(serialized).toEqual({
+      type: 'possible',
+      transactions: [
+        {
+          from: '0x123',
+          to: '0x456',
+          value: '123',
+          gas: '456',
+          maxFeePerGas: '789',
+          maxPriorityFeePerGas: '1011',
+        },
+      ],
+      feeCurrency: getSerializableTokenBalance(mockFeeCurrency),
+    })
+  })
+})
+
+describe(getDeserializedPossibleTransaction, () => {
+  const serializedPossibleTransaction: SerializablePreparedTransactionsPossible = {
+    type: 'possible',
+    transactions: [
+      {
+        from: '0x123',
+        to: '0x456',
+        value: '123',
+        gas: '456',
+        maxFeePerGas: '789',
+        maxPriorityFeePerGas: '1011',
+      },
+    ],
+    feeCurrency: getSerializableTokenBalance(mockFeeCurrency),
+  }
+
+  it('should deserialize possible transaction by converting string fields back to bigint', () => {
+    const deserialized = getDeserializedPossibleTransaction(serializedPossibleTransaction)
+    expect(deserialized).toEqual({
+      type: 'possible',
+      transactions: [
+        {
+          from: '0x123',
+          to: '0x456',
+          value: BigInt(123),
+          gas: BigInt(456),
+          maxFeePerGas: BigInt(789),
+          maxPriorityFeePerGas: BigInt(1011),
+        },
+      ],
+      feeCurrency: getDeserializedTokenBalance(serializedPossibleTransaction.feeCurrency),
+    })
   })
 })

--- a/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.test.ts
+++ b/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.test.ts
@@ -1,10 +1,10 @@
 import BigNumber from 'bignumber.js'
 import type { PreparedTransactionsPossible } from 'src/public'
-import { getDeserializedTokenBalance, getSerializableTokenBalance } from 'src/tokens/utils'
+import { getSerializableTokenBalance, getTokenBalance } from 'src/tokens/utils'
 import { NetworkId } from 'src/transactions/types'
 import {
-  getDeserializedPossibleTransaction,
   getPreparedTransactions,
+  getPreparedTransactionsPossible,
   getSerializablePreparedTransactions,
   getSerializablePreparedTransactionsPossible,
   type SerializablePreparedTransactionsPossible,
@@ -156,7 +156,7 @@ describe(getSerializablePreparedTransactionsPossible, () => {
   })
 })
 
-describe(getDeserializedPossibleTransaction, () => {
+describe(getPreparedTransactionsPossible, () => {
   const serializedPossibleTransaction: SerializablePreparedTransactionsPossible = {
     type: 'possible',
     transactions: [
@@ -173,7 +173,7 @@ describe(getDeserializedPossibleTransaction, () => {
   }
 
   it('should deserialize possible transaction by converting string fields back to bigint', () => {
-    const deserialized = getDeserializedPossibleTransaction(serializedPossibleTransaction)
+    const deserialized = getPreparedTransactionsPossible(serializedPossibleTransaction)
     expect(deserialized).toEqual({
       type: 'possible',
       transactions: [
@@ -186,7 +186,7 @@ describe(getDeserializedPossibleTransaction, () => {
           maxPriorityFeePerGas: BigInt(1011),
         },
       ],
-      feeCurrency: getDeserializedTokenBalance(serializedPossibleTransaction.feeCurrency),
+      feeCurrency: getTokenBalance(serializedPossibleTransaction.feeCurrency),
     })
   })
 })

--- a/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
+++ b/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
@@ -1,6 +1,8 @@
 // Helper functions making prepared transactions serializable
 // so they can be used in redux actions (or even stores).
-import { TransactionRequest } from 'src/viem/prepareTransactions'
+import type { SerializedTokenBalance } from 'src/tokens/slice'
+import { getDeserializedTokenBalance, getSerializableTokenBalance } from 'src/tokens/utils'
+import type { PreparedTransactionsPossible, TransactionRequest } from 'src/viem/prepareTransactions'
 
 const bigIntProps = [
   'value',
@@ -67,4 +69,32 @@ export function getPreparedTransactions(
   preparedTransactions: SerializableTransactionRequest[]
 ): TransactionRequest[] {
   return preparedTransactions.map(getPreparedTransaction)
+}
+
+export type SerializablePreparedTransactionsPossible = Pick<
+  PreparedTransactionsPossible,
+  'type'
+> & {
+  transactions: SerializableTransactionRequest[]
+  feeCurrency: SerializedTokenBalance
+}
+
+export function getSerializablePossibleTransaction(
+  possibleTransaction: PreparedTransactionsPossible
+): SerializablePreparedTransactionsPossible {
+  return {
+    type: 'possible',
+    transactions: getSerializablePreparedTransactions(possibleTransaction.transactions),
+    feeCurrency: getSerializableTokenBalance(possibleTransaction.feeCurrency),
+  }
+}
+
+export function getDeserializedPossibleTransaction(
+  serializedTransaction: SerializablePreparedTransactionsPossible
+): PreparedTransactionsPossible {
+  return {
+    type: 'possible',
+    transactions: getPreparedTransactions(serializedTransaction.transactions),
+    feeCurrency: getDeserializedTokenBalance(serializedTransaction.feeCurrency),
+  }
 }

--- a/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
+++ b/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
@@ -1,7 +1,7 @@
 // Helper functions making prepared transactions serializable
 // so they can be used in redux actions (or even stores).
 import type { SerializedTokenBalance } from 'src/tokens/slice'
-import { getDeserializedTokenBalance, getSerializableTokenBalance } from 'src/tokens/utils'
+import { getSerializableTokenBalance, getTokenBalance } from 'src/tokens/utils'
 import type { PreparedTransactionsPossible, TransactionRequest } from 'src/viem/prepareTransactions'
 
 const bigIntProps = [
@@ -95,6 +95,6 @@ export function getPreparedTransactionsPossible(
   return {
     type: 'possible',
     transactions: getPreparedTransactions(serializedTransaction.transactions),
-    feeCurrency: getDeserializedTokenBalance(serializedTransaction.feeCurrency),
+    feeCurrency: getTokenBalance(serializedTransaction.feeCurrency),
   }
 }

--- a/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
+++ b/packages/@divvi/mobile/src/viem/preparedTransactionSerialization.ts
@@ -79,7 +79,7 @@ export type SerializablePreparedTransactionsPossible = Pick<
   feeCurrency: SerializedTokenBalance
 }
 
-export function getSerializablePossibleTransaction(
+export function getSerializablePreparedTransactionsPossible(
   possibleTransaction: PreparedTransactionsPossible
 ): SerializablePreparedTransactionsPossible {
   return {
@@ -89,7 +89,7 @@ export function getSerializablePossibleTransaction(
   }
 }
 
-export function getDeserializedPossibleTransaction(
+export function getPreparedTransactionsPossible(
   serializedTransaction: SerializablePreparedTransactionsPossible
 ): PreparedTransactionsPossible {
   return {

--- a/packages/@divvi/mobile/test/RootStateSchema.json
+++ b/packages/@divvi/mobile/test/RootStateSchema.json
@@ -1949,7 +1949,7 @@
                             "type": "number"
                         },
                         "price": {
-                            "$ref": "#/definitions/BigNumber.Value"
+                            "type": "string"
                         }
                     },
                     "required": [


### PR DESCRIPTION
### Description
Based on [this](https://github.com/divvi-xyz/divvi-mobile/pull/102#discussion_r1977255177) and [this](https://github.com/divvi-xyz/divvi-mobile/pull/136#discussion_r1985851448) review comments it appeared valuable to have a way to serialize/deserialize possible prepared transaction results in order to be able to pass those as a params of the screen using `react-navigation`. In order to achieve this – `TokenBalance` also needed to have a (de)serialization mechanism as `PreparedTransactionsPossible` has a `feeCurrency` property which is of that type. It is used by `getFeeCurrencyAndAmounts`. 

This appeared needed after working on `SendConfirmation` and new `EarnDepositConfirmationScreen` screens.

This PR adds:
- serialization/deserialization functions for TokenBalance
- serialization/deserialization functions for PreparedTransactionsPossible
- applying this logic to `SendConfirmation` screen.
### Test plan
- added tests for serialization/deserialization of token balances
- added tests for serialization/deserialization of possible prepared transaction results

### Related issues

Relates to [ENG-184](https://linear.app/valora/issue/ENG-184/%5Bwallet%5D-add-new-reviewtransaction-component-to-earndepositbottomsheet)

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
