### PR TITLE
fix: update `@crowdin/ota-client` to fix axios vulnerability issue

### DIFF
--- a/packages/@divvi/mobile/locales/index.ts
+++ b/packages/@divvi/mobile/locales/index.ts
@@ -6,6 +6,7 @@ interface Locales {
         name: string
         strings: any
         dateFns: Locale
+        crowdinConfig: { langCode: string; osx_code?: string }
       }
     | undefined
 }
@@ -21,6 +22,9 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/en-US').enUS
     },
+    get crowdinConfig() {
+      return { langCode: 'en' }
+    },
   },
   'es-419': {
     name: 'Español',
@@ -31,6 +35,9 @@ const locales: Locales = {
     },
     get dateFns() {
       return require('date-fns/locale/es').es
+    },
+    get crowdinConfig() {
+      return { langCode: 'es', osx_code: 'es-419.lproj' }
     },
   },
   'pt-BR': {
@@ -43,6 +50,9 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/pt-BR').ptBR
     },
+    get crowdinConfig() {
+      return { langCode: 'pt-BR' }
+    },
   },
   de: {
     name: 'Deutsch',
@@ -53,6 +63,9 @@ const locales: Locales = {
     },
     get dateFns() {
       return require('date-fns/locale/de').de
+    },
+    get crowdinConfig() {
+      return { langCode: 'de' }
     },
   },
   'ru-RU': {
@@ -65,6 +78,9 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/ru').ru
     },
+    get crowdinConfig() {
+      return { langCode: 'ru' }
+    },
   },
   'fr-FR': {
     name: 'Français',
@@ -75,6 +91,9 @@ const locales: Locales = {
     },
     get dateFns() {
       return require('date-fns/locale/fr').fr
+    },
+    get crowdinConfig() {
+      return { langCode: 'fr' }
     },
   },
   'it-IT': {
@@ -87,6 +106,9 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/it').it
     },
+    get crowdinConfig() {
+      return { langCode: 'it' }
+    },
   },
   'uk-UA': {
     name: 'Українська',
@@ -97,6 +119,9 @@ const locales: Locales = {
     },
     get dateFns() {
       return require('date-fns/locale/uk').uk
+    },
+    get crowdinConfig() {
+      return { langCode: 'uk' }
     },
   },
   'th-TH': {
@@ -109,6 +134,9 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/th').th
     },
+    get crowdinConfig() {
+      return { langCode: 'th' }
+    },
   },
   'tr-TR': {
     name: 'Türkçe',
@@ -119,6 +147,9 @@ const locales: Locales = {
     },
     get dateFns() {
       return require('date-fns/locale/tr').tr
+    },
+    get crowdinConfig() {
+      return { langCode: 'tr' }
     },
   },
   'pl-PL': {
@@ -131,6 +162,9 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/pl').pl
     },
+    get crowdinConfig() {
+      return { langCode: 'pl' }
+    },
   },
   'vi-VN': {
     name: 'Tiếng Việt',
@@ -142,6 +176,9 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/vi').vi
     },
+    get crowdinConfig() {
+      return { langCode: 'vi' }
+    },
   },
   'zh-CN': {
     name: '简体中文',
@@ -152,6 +189,9 @@ const locales: Locales = {
     },
     get dateFns() {
       return require('date-fns/locale/zh-CN').zhCN
+    },
+    get crowdinConfig() {
+      return { langCode: 'zh' }
     },
   },
 }

--- a/packages/@divvi/mobile/locales/index.ts
+++ b/packages/@divvi/mobile/locales/index.ts
@@ -6,11 +6,6 @@ interface Locales {
         name: string
         strings: any
         dateFns: Locale
-        /**
-         * List of supported language codes by Crowdin:
-         * https://support.crowdin.com/developer/language-codes/
-         */
-        crowdinConfig: { langCode: string; osx_code?: string }
       }
     | undefined
 }
@@ -26,7 +21,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/en-US').enUS
     },
-    crowdinConfig: { langCode: 'en' },
   },
   'es-419': {
     name: 'Español',
@@ -38,7 +32,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/es').es
     },
-    crowdinConfig: { langCode: 'es', osx_code: 'es-419.lproj' },
   },
   'pt-BR': {
     name: 'Português',
@@ -50,7 +43,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/pt-BR').ptBR
     },
-    crowdinConfig: { langCode: 'pt-BR' },
   },
   de: {
     name: 'Deutsch',
@@ -62,7 +54,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/de').de
     },
-    crowdinConfig: { langCode: 'de' },
   },
   'ru-RU': {
     name: 'Pyccкий',
@@ -74,7 +65,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/ru').ru
     },
-    crowdinConfig: { langCode: 'ru' },
   },
   'fr-FR': {
     name: 'Français',
@@ -86,7 +76,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/fr').fr
     },
-    crowdinConfig: { langCode: 'fr' },
   },
   'it-IT': {
     name: 'Italiano',
@@ -98,7 +87,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/it').it
     },
-    crowdinConfig: { langCode: 'it' },
   },
   'uk-UA': {
     name: 'Українська',
@@ -110,7 +98,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/uk').uk
     },
-    crowdinConfig: { langCode: 'uk' },
   },
   'th-TH': {
     name: 'ไทย',
@@ -122,7 +109,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/th').th
     },
-    crowdinConfig: { langCode: 'th' },
   },
   'tr-TR': {
     name: 'Türkçe',
@@ -134,7 +120,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/tr').tr
     },
-    crowdinConfig: { langCode: 'tr' },
   },
   'pl-PL': {
     name: 'Polski',
@@ -146,7 +131,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/pl').pl
     },
-    crowdinConfig: { langCode: 'pl' },
   },
   'vi-VN': {
     name: 'Tiếng Việt',
@@ -158,7 +142,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/vi').vi
     },
-    crowdinConfig: { langCode: 'vi' },
   },
   'zh-CN': {
     name: '简体中文',
@@ -170,7 +153,6 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/zh-CN').zhCN
     },
-    crowdinConfig: { langCode: 'zh' },
   },
 }
 

--- a/packages/@divvi/mobile/locales/index.ts
+++ b/packages/@divvi/mobile/locales/index.ts
@@ -26,9 +26,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/en-US').enUS
     },
-    get crowdinConfig() {
-      return { langCode: 'en' }
-    },
+    crowdinConfig: { langCode: 'en' },
   },
   'es-419': {
     name: 'Español',
@@ -40,9 +38,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/es').es
     },
-    get crowdinConfig() {
-      return { langCode: 'es', osx_code: 'es-419.lproj' }
-    },
+    crowdinConfig: { langCode: 'es', osx_code: 'es-419.lproj' },
   },
   'pt-BR': {
     name: 'Português',
@@ -54,9 +50,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/pt-BR').ptBR
     },
-    get crowdinConfig() {
-      return { langCode: 'pt-BR' }
-    },
+    crowdinConfig: { langCode: 'pt-BR' },
   },
   de: {
     name: 'Deutsch',
@@ -68,9 +62,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/de').de
     },
-    get crowdinConfig() {
-      return { langCode: 'de' }
-    },
+    crowdinConfig: { langCode: 'de' },
   },
   'ru-RU': {
     name: 'Pyccкий',
@@ -82,9 +74,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/ru').ru
     },
-    get crowdinConfig() {
-      return { langCode: 'ru' }
-    },
+    crowdinConfig: { langCode: 'ru' },
   },
   'fr-FR': {
     name: 'Français',
@@ -96,9 +86,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/fr').fr
     },
-    get crowdinConfig() {
-      return { langCode: 'fr' }
-    },
+    crowdinConfig: { langCode: 'fr' },
   },
   'it-IT': {
     name: 'Italiano',
@@ -110,9 +98,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/it').it
     },
-    get crowdinConfig() {
-      return { langCode: 'it' }
-    },
+    crowdinConfig: { langCode: 'it' },
   },
   'uk-UA': {
     name: 'Українська',
@@ -124,9 +110,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/uk').uk
     },
-    get crowdinConfig() {
-      return { langCode: 'uk' }
-    },
+    crowdinConfig: { langCode: 'uk' },
   },
   'th-TH': {
     name: 'ไทย',
@@ -138,9 +122,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/th').th
     },
-    get crowdinConfig() {
-      return { langCode: 'th' }
-    },
+    crowdinConfig: { langCode: 'th' },
   },
   'tr-TR': {
     name: 'Türkçe',
@@ -152,9 +134,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/tr').tr
     },
-    get crowdinConfig() {
-      return { langCode: 'tr' }
-    },
+    crowdinConfig: { langCode: 'tr' },
   },
   'pl-PL': {
     name: 'Polski',
@@ -166,9 +146,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/pl').pl
     },
-    get crowdinConfig() {
-      return { langCode: 'pl' }
-    },
+    crowdinConfig: { langCode: 'pl' },
   },
   'vi-VN': {
     name: 'Tiếng Việt',
@@ -180,9 +158,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/vi').vi
     },
-    get crowdinConfig() {
-      return { langCode: 'vi' }
-    },
+    crowdinConfig: { langCode: 'vi' },
   },
   'zh-CN': {
     name: '简体中文',
@@ -194,9 +170,7 @@ const locales: Locales = {
     get dateFns() {
       return require('date-fns/locale/zh-CN').zhCN
     },
-    get crowdinConfig() {
-      return { langCode: 'zh' }
-    },
+    crowdinConfig: { langCode: 'zh' },
   },
 }
 

--- a/packages/@divvi/mobile/locales/index.ts
+++ b/packages/@divvi/mobile/locales/index.ts
@@ -6,6 +6,10 @@ interface Locales {
         name: string
         strings: any
         dateFns: Locale
+        /**
+         * List of supported language codes by Crowdin:
+         * https://support.crowdin.com/developer/language-codes/
+         */
         crowdinConfig: { langCode: string; osx_code?: string }
       }
     | undefined

--- a/packages/@divvi/mobile/package.json
+++ b/packages/@divvi/mobile/package.json
@@ -176,7 +176,7 @@
   },
   "dependencies": {
     "@badrap/result": "~0.2.13",
-    "@crowdin/ota-client": "^0.7.0",
+    "@crowdin/ota-client": "^2.0.1",
     "@fiatconnect/fiatconnect-sdk": "^0.5.74",
     "@fiatconnect/fiatconnect-types": "^13.3.11",
     "@gorhom/bottom-sheet": "^5.1.1",

--- a/packages/@divvi/mobile/src/i18n/saga.test.ts
+++ b/packages/@divvi/mobile/src/i18n/saga.test.ts
@@ -16,7 +16,6 @@ import { otaTranslationsUpdated } from 'src/i18n/slice'
 jest.mock('@crowdin/ota-client', () => {
   return function () {
     return {
-      setCurrentLocale: jest.fn(),
       getManifestTimestamp: jest.fn(() => 123456),
       getStringsByLocale: jest.fn(() => ({
         someLang: { someNamespace: { someKey: 'someValue ' } },

--- a/packages/@divvi/mobile/src/i18n/saga.test.ts
+++ b/packages/@divvi/mobile/src/i18n/saga.test.ts
@@ -16,8 +16,8 @@ import { otaTranslationsUpdated } from 'src/i18n/slice'
 jest.mock('@crowdin/ota-client', () => {
   return function () {
     return {
+      setCurrentLocale: jest.fn(),
       getManifestTimestamp: jest.fn(() => 123456),
-      getLanguageMappings: jest.fn(),
       getStringsByLocale: jest.fn(() => ({
         someLang: { someNamespace: { someKey: 'someValue ' } },
       })),

--- a/packages/@divvi/mobile/src/i18n/saga.ts
+++ b/packages/@divvi/mobile/src/i18n/saga.ts
@@ -1,6 +1,5 @@
 import OtaClient from '@crowdin/ota-client'
 import i18n from 'i18next'
-import locales from 'locales'
 import DeviceInfo from 'react-native-device-info'
 import {
   CROWDIN_DISTRIBUTION_HASH,
@@ -22,6 +21,26 @@ import { call, put, select, spawn, takeLatest } from 'typed-redux-saga'
 const TAG = 'i18n/saga'
 const allowOtaTranslations = ENABLE_OTA_TRANSLATIONS
 
+/**
+ * List of supported language codes by Crowdin:
+ * https://support.crowdin.com/developer/language-codes/
+ */
+const CROWDING_LANG_CODE_MAPPINGS: Record<string, { langCode: string; osx_code?: string }> = {
+  'en-US': { langCode: 'en' },
+  'es-419': { langCode: 'es', osx_code: 'es-419.lproj' },
+  'pt-BR': { langCode: 'pt-BR' },
+  de: { langCode: 'de' },
+  'ru-RU': { langCode: 'ru' },
+  'fr-FR': { langCode: 'fr' },
+  'it-IT': { langCode: 'it' },
+  'uk-UA': { langCode: 'uk' },
+  'th-TH': { langCode: 'th' },
+  'tr-TR': { langCode: 'tr' },
+  'pl-PL': { langCode: 'pl' },
+  'vi-VN': { langCode: 'vi' },
+  'zh-CN': { langCode: 'zh-CN' },
+}
+
 export function* handleFetchOtaTranslations() {
   if (allowOtaTranslations) {
     try {
@@ -32,7 +51,7 @@ export function* handleFetchOtaTranslations() {
         return
       }
 
-      const customMappedLanguage = locales[currentLanguage]?.crowdinConfig.langCode
+      const customMappedLanguage = CROWDING_LANG_CODE_MAPPINGS[currentLanguage]?.langCode
       const otaClient = new OtaClient(CROWDIN_DISTRIBUTION_HASH, {
         languageCode: customMappedLanguage || currentLanguage || DEFAULT_APP_LANGUAGE,
       })

--- a/packages/@divvi/mobile/src/i18n/saga.ts
+++ b/packages/@divvi/mobile/src/i18n/saga.ts
@@ -1,6 +1,6 @@
 import OtaClient from '@crowdin/ota-client'
 import i18n from 'i18next'
-import _ from 'lodash'
+import locales from 'locales'
 import DeviceInfo from 'react-native-device-info'
 import {
   CROWDIN_DISTRIBUTION_HASH,
@@ -32,22 +32,7 @@ export function* handleFetchOtaTranslations() {
         return
       }
 
-      const response = yield* call(
-        fetch,
-        `${OtaClient.BASE_URL}/${CROWDIN_DISTRIBUTION_HASH}/manifest.json`,
-        { method: 'GET', headers: { 'Content-Type': 'application/json' } }
-      )
-      const result = yield* call([response, 'json'])
-      const customMappedLanguage = _.findKey(
-        result && 'language_mapping' in result
-          ? result.language_mapping
-          : {
-              es: { locale: 'es-419', osx_code: 'es-419.lproj' },
-              de: { locale: 'de' },
-            },
-        { locale: currentLanguage }
-      )
-
+      const customMappedLanguage = locales[currentLanguage]?.crowdinConfig.langCode
       const otaClient = new OtaClient(CROWDIN_DISTRIBUTION_HASH, {
         languageCode: customMappedLanguage || currentLanguage || DEFAULT_APP_LANGUAGE,
       })
@@ -61,11 +46,7 @@ export function* handleFetchOtaTranslations() {
         lastFetchTime !== timestamp ||
         DeviceInfo.getVersion() !== lastFetchAppVersion
       ) {
-        const translations = yield* call(
-          [otaClient, otaClient.getStringsByLocale],
-          undefined,
-          customMappedLanguage || currentLanguage
-        )
+        const translations = yield* call([otaClient, otaClient.getStringsByLocale])
         i18n.addResourceBundle(currentLanguage, 'translation', translations, true, true)
 
         yield* call(saveOtaTranslations, { [currentLanguage]: translations })

--- a/packages/@divvi/mobile/src/i18n/saga.ts
+++ b/packages/@divvi/mobile/src/i18n/saga.ts
@@ -15,7 +15,7 @@ import { safely } from 'src/utils/safely'
 import { call, put, select, spawn, takeLatest } from 'typed-redux-saga'
 
 const TAG = 'i18n/saga'
-const otaClient = new OtaClient(CROWDIN_DISTRIBUTION_HASH)
+const DEFAULT_LANG_CODE = 'en-US'
 const allowOtaTranslations = ENABLE_OTA_TRANSLATIONS
 
 export function* handleFetchOtaTranslations() {
@@ -28,6 +28,9 @@ export function* handleFetchOtaTranslations() {
         return
       }
 
+      const otaClient = new OtaClient(CROWDIN_DISTRIBUTION_HASH, {
+        languageCode: DEFAULT_LANG_CODE,
+      })
       const lastFetchLanguage = yield* select(otaTranslationsLanguageSelector)
       const lastFetchTime = yield* select(otaTranslationsLastUpdateSelector)
       const timestamp = yield* call([otaClient, otaClient.getManifestTimestamp])
@@ -38,8 +41,6 @@ export function* handleFetchOtaTranslations() {
         lastFetchTime !== timestamp ||
         DeviceInfo.getVersion() !== lastFetchAppVersion
       ) {
-        yield* call([otaClient, otaClient.setCurrentLocale], currentLanguage)
-
         const translations = yield* call(
           [otaClient, otaClient.getStringsByLocale],
           undefined,

--- a/packages/@divvi/mobile/src/i18n/saga.ts
+++ b/packages/@divvi/mobile/src/i18n/saga.ts
@@ -1,6 +1,5 @@
 import OtaClient from '@crowdin/ota-client'
 import i18n from 'i18next'
-import _ from 'lodash'
 import DeviceInfo from 'react-native-device-info'
 import { CROWDIN_DISTRIBUTION_HASH, ENABLE_OTA_TRANSLATIONS } from 'src/config'
 import { saveOtaTranslations } from 'src/i18n/otaTranslations'
@@ -39,13 +38,12 @@ export function* handleFetchOtaTranslations() {
         lastFetchTime !== timestamp ||
         DeviceInfo.getVersion() !== lastFetchAppVersion
       ) {
-        const languageMappings = yield* call([otaClient, otaClient.getLanguageMappings])
-        const customMappedLanguage = _.findKey(languageMappings, { locale: currentLanguage })
+        yield* call([otaClient, otaClient.setCurrentLocale], currentLanguage)
 
         const translations = yield* call(
           [otaClient, otaClient.getStringsByLocale],
           undefined,
-          customMappedLanguage || currentLanguage
+          currentLanguage
         )
         i18n.addResourceBundle(currentLanguage, 'translation', translations, true, true)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,12 +1195,10 @@
     ieee754 "^1.2.1"
     react-native-quick-base64 "^2.0.5"
 
-"@crowdin/ota-client@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@crowdin/ota-client/-/ota-client-0.7.0.tgz#6aef4f4be90b7f931175a274c68b669ef4044c6b"
-  integrity sha512-RNFnR2ter5dsFJlyQysT8jswDn/TBF/ALosiDRpaj2tcOlAk/amQOoqEMJrCdR46xWqMUNwz/hJ4YIlcN51kPQ==
-  dependencies:
-    axios "0.25.0"
+"@crowdin/ota-client@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@crowdin/ota-client/-/ota-client-2.0.1.tgz#27f6c92d46d6b16aadd860f04ce5e9b73c19356b"
+  integrity sha512-iIg3jjWQFUROWgOpghmDXbyAGhYCz4bXbLaYuTGIc2fvlON6OY4+osTT9c/bL6gLct4zw8mF25+AWXf9m+X+Zg==
 
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"
@@ -6268,13 +6266,6 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
-  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
-  dependencies:
-    follow-redirects "^1.14.7"
-
 axios@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
@@ -9396,11 +9387,6 @@ flow-parser@0.*:
   version "0.206.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.206.0.tgz#f4f794f8026535278393308e01ea72f31000bfef"
   integrity sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==
-
-follow-redirects@^1.14.7:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 follow-redirects@^1.14.8:
   version "1.15.9"


### PR DESCRIPTION
### Description
Current `axios` [vulnarability](https://github.com/divvi-xyz/divvi-mobile/actions/runs/13787562981/job/38559105563?pr=141) is caused by the outdated `@crowdin/ota-client` library. We are still using version `^0.7.0` while the latest is `2.0.1`.
Since `2.0` they dropped axios dependency so now its a fully "independent" package.

#### Migration to `1.0` ([docs](https://crowdin.github.io/ota-client-js/releases/migration-1))
Migration from `0.7` to `1.0`  involves removal of a few API functions. There was a single usage of `getLanguageMappings` in our codebase so when I removed it I've tried to change the language and received this error:
```
ERROR  i18n/saga@handleFetchOtaTranslations :: Failed to fetch OTA translations :: Language code should be either provided through input arguments or by "setCurrentLocale" method in Error: Language code should be either provided through input arguments or by "setCurrentLocale" meth :: network connected true
```
So I've added a call of `setCurrentLocale` function and it seemed to fix the issue.

UPD: As per [Kathy's comment](https://github.com/divvi-xyz/divvi-mobile/pull/142#discussion_r1989351308) I removed usage of `setCurrentLocale` and replaced it with instantiation of the `OtaClient` and providing fallback lang code in the saga.

#### Migration to `2.0` ([docs](https://crowdin.github.io/ota-client-js/releases/migration-2))
As we haven't used custom `axios` instance - no extra steps needed for this migration.


### Test plan
All the tests pass.

### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
