### PR TITLE
fix: avoid background flicker during startup

### DIFF
--- a/packages/@divvi/mobile/src/navigator/Navigator.tsx
+++ b/packages/@divvi/mobile/src/navigator/Navigator.tsx
@@ -638,10 +638,6 @@ function MainStackScreen() {
 
     setInitialRoute(initialRoute)
     Logger.info(`${TAG}@MainStackScreen`, `Initial route: ${initialRoute}`)
-
-    // Wait for next frame to avoid slight gap when hiding the
-    // TODO: make this work with the expo splash screen
-    // requestAnimationFrame(() => SplashScreen.hide())
   }, [])
 
   if (!initialRouteName) {

--- a/packages/@divvi/mobile/src/navigator/NavigatorWrapper.tsx
+++ b/packages/@divvi/mobile/src/navigator/NavigatorWrapper.tsx
@@ -3,6 +3,7 @@ import { useLogger } from '@react-navigation/devtools'
 import { NavigationContainer, NavigationState } from '@react-navigation/native'
 import * as Sentry from '@sentry/react-native'
 import { SeverityLevel } from '@sentry/types'
+import * as SplashScreen from 'expo-splash-screen'
 import * as React from 'react'
 import { StyleSheet, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
@@ -37,6 +38,8 @@ import Logger from 'src/utils/Logger'
 import { userInSanctionedCountrySelector } from 'src/utils/countryFeatures'
 import { isVersionBelowMinimum } from 'src/utils/versionCheck'
 import { demoModeEnabledSelector } from 'src/web3/selectors'
+
+SplashScreen.preventAutoHideAsync().catch((e) => Logger.error('SplashSceen', e))
 
 // This uses RN Navigation's experimental nav state persistence
 // to improve the hot reloading experience when in DEV mode
@@ -168,6 +171,9 @@ export const NavigatorWrapper = () => {
   const onReady = () => {
     navigatorIsReadyRef.current = true
     sentryRoutingInstrumentation.registerNavigationContainer(navigationRef)
+    requestAnimationFrame(() =>
+      SplashScreen.hideAsync().catch((e) => Logger.error('SplashSceen', e))
+    )
   }
 
   return (


### PR DESCRIPTION
### Description

Avoid background flicker during startup by keeping the splash screen visible until it is explicitly dismissed when the navigator is ready. 

### Test plan

* Visual assessment
* CI

### Related issues

- Related to ENG-185

### Backwards compatibility

Y

### Network scalability

NA

| Before | After |
|--------|--------|
|  ![before](https://github.com/user-attachments/assets/3f021c30-b9f1-4b68-b23e-34f0d7274442) |  ![after](https://github.com/user-attachments/assets/f517d7a7-5943-48b2-aba0-52700bbf79ae) | 