### PR TITLE
fix(onboarding): update recovery styles

### DIFF
--- a/packages/@divvi/mobile/src/components/RecoveryPhraseInput.tsx
+++ b/packages/@divvi/mobile/src/components/RecoveryPhraseInput.tsx
@@ -63,15 +63,22 @@ export default function RecoveryPhraseInput({
 
   const showInput = status === RecoveryPhraseInputStatus.Inputting
   const showStatus = status === RecoveryPhraseInputStatus.Processing
+  const showPaste = shouldShowClipboardInternal()
   const keyboardType = Platform.OS === 'android' ? 'visible-password' : undefined
 
   return (
     <Card rounded={true} shadow={null} style={styles.container}>
       {/* These views cannot be combined as it will cause the shadow to be clipped on iOS */}
       <View style={styles.containRadius}>
-        <View style={[showInput ? styles.contentActiveLong : styles.contentLong]}>
+        <View
+          style={[
+            styles.content,
+            showInput ? styles.contentActive : styles.contentInactive,
+            showInput && showPaste && styles.contentActiveWithPaste,
+          ]}
+        >
           <View style={styles.innerContent}>
-            <Text style={showInput ? styles.labelActiveLong : styles.labelLong}>
+            <Text style={[styles.label, !showInput && styles.labelInactive]}>
               {t('accountKey')}
             </Text>
             {showInput ? (
@@ -120,7 +127,7 @@ export default function RecoveryPhraseInput({
         {showInput && (
           <ClipboardAwarePasteButton
             getClipboardContent={getFreshClipboardContent}
-            shouldShow={shouldShowClipboardInternal()}
+            shouldShow={showPaste}
             onPress={onInputChange}
           />
         )}
@@ -143,32 +150,32 @@ const styles = StyleSheet.create({
     borderRadius: Spacing.Smallest8,
     overflow: 'hidden',
   },
-  contentLong: {
+  content: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     padding: Spacing.Regular16,
+  },
+  contentInactive: {
     paddingVertical: Spacing.Small12,
   },
-  contentActiveLong: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: Spacing.Regular16,
-    paddingBottom: 4,
+  contentActive: {
+    paddingBottom: Spacing.Tiny4,
+  },
+  contentActiveWithPaste: {
     borderBottomWidth: 1,
     borderColor: colors.borderSecondary,
   },
   innerContent: {
     flex: 1,
   },
-  labelLong: {
+  label: {
     ...typeScale.labelSemiBoldSmall,
+  },
+  labelInactive: {
     color: colors.contentSecondary,
     opacity: 0.5,
     marginBottom: 4,
-  },
-  labelActiveLong: {
-    ...typeScale.labelSemiBoldSmall,
   },
   codeValueLong: {
     ...typeScale.bodyMedium,

--- a/packages/@divvi/mobile/src/onboarding/registration/ImportSelect.tsx
+++ b/packages/@divvi/mobile/src/onboarding/registration/ImportSelect.tsx
@@ -20,7 +20,7 @@ import TopBarTextButtonOnboarding from 'src/onboarding/TopBarTextButtonOnboardin
 import { useDispatch } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
-import { Shadow, Spacing } from 'src/styles/styles'
+import { Spacing } from 'src/styles/styles'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.ImportSelect>
 
@@ -38,7 +38,7 @@ function ActionCard({
   testID?: string
 }) {
   return (
-    <Card style={styles.card} rounded={true} shadow={Shadow.SoftLight} testID={testID}>
+    <Card style={styles.card} rounded={true} shadow={null} testID={testID}>
       <Touchable borderRadius={8} style={styles.touchable} onPress={onPress}>
         <>
           <View style={styles.topLine}>
@@ -89,7 +89,7 @@ export default function ImportSelect({ navigation }: Props) {
           <ActionCard
             title={t('importSelect.emailAndPhone.title')}
             description={t('importSelect.emailAndPhone.description')}
-            icon={<CloudCheck color={colors.successPrimary} />}
+            icon={<CloudCheck color={colors.contentPrimary} />}
             onPress={() =>
               navigate(Screens.SignInWithEmail, {
                 keylessBackupFlow: KeylessBackupFlow.Restore,
@@ -101,7 +101,7 @@ export default function ImportSelect({ navigation }: Props) {
           <ActionCard
             title={t('importSelect.recoveryPhrase.title')}
             description={t('importSelect.recoveryPhrase.description')}
-            icon={<Lock color={colors.successPrimary} />}
+            icon={<Lock color={colors.contentPrimary} />}
             onPress={() => navigate(Screens.ImportWallet, { clean: true })}
             testID="ImportSelect/Mnemonic"
           />
@@ -123,6 +123,8 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 0,
     backgroundColor: colors.backgroundSecondary,
+    borderWidth: 1,
+    borderColor: colors.borderPrimary,
   },
   cardDescription: {
     ...typeScale.bodySmall,
@@ -130,7 +132,7 @@ const styles = StyleSheet.create({
   },
   cardTitle: {
     ...typeScale.labelMedium,
-    color: colors.successPrimary,
+    color: colors.contentPrimary,
     flex: 1,
   },
   safeArea: {


### PR DESCRIPTION
### Description

- Per design feedback (row 2 [here](https://docs.google.com/spreadsheets/d/1CDXdRtVm9HJnBxorAt7Og29fUpnlsk-cPnQE3mMq5sM/edit?gid=0#gid=0))
- Fix extra border on recovery phrase input

### Test plan

Manually by running through the recovery flow. (Need to enable cloudBackup in apps/example config for the import selection to show up)

| Feature | Before | After |
|--------|--------|--------|
| Recovery selection | <img src="https://github.com/user-attachments/assets/35e960d6-17b4-4a91-a467-fc71741a7742" width="250" /> | <img src="https://github.com/user-attachments/assets/b4fe9e63-fdb8-40fc-b6cb-66af6e42f07c" width="250" /> |
| Recovery phrase input no paste | <img src="https://github.com/user-attachments/assets/2a89ad72-1a50-4b0a-b8ef-3d9a70b4fdf3" width="250" /> | <img src="https://github.com/user-attachments/assets/385a8f7e-4423-4dcb-b227-96d7cc946e41" width="250" /> | 
| Recovery phrase input with paste <br/> (no visible change) | <img src="https://github.com/user-attachments/assets/a5813e48-992a-41a2-89ff-989059844d20" width="250" /> | <img src="https://github.com/user-attachments/assets/9749540c-afc3-4e9e-9196-da74d4218913" width="250" /> |

### Related issues

- Part of ENG-193

