### PR TITLE
feat(config): allow configuring network ids

### DIFF
--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -332,10 +332,10 @@ optional networks: object;
 
 Defined in: [packages/@divvi/mobile/src/public/types.tsx:180](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L180)
 
-#### enabledIds?
+#### enabledNetworkIds?
 
 ```ts
-optional enabledIds: NetworkId[];
+optional enabledNetworkIds: NetworkId[];
 ```
 
 ---

--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -40,7 +40,7 @@ Defined in: [packages/@divvi/mobile/src/public/types.tsx:26](https://github.com/
 optional divviProtocol: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:225](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L225)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:226](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L226)
 
 #### protocolIds
 
@@ -70,7 +70,7 @@ referrerId: string
 optional experimental: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:190](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L190)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:191](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L191)
 
 Experimental features that may change or be removed in future versions.
 These features are not part of the stable configuration API and should be used with caution.
@@ -331,6 +331,12 @@ optional networks: object;
 ```
 
 Defined in: [packages/@divvi/mobile/src/public/types.tsx:180](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L180)
+
+#### enabledIds?
+
+```ts
+optional enabledIds: NetworkId[];
+```
 
 ---
 

--- a/docs/reference/type-aliases/NetworkId.md
+++ b/docs/reference/type-aliases/NetworkId.md
@@ -22,4 +22,4 @@ type NetworkId =
   | 'base-sepolia'
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:232](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L232)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:233](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L233)

--- a/packages/@divvi/mobile/src/public/createApp.ts
+++ b/packages/@divvi/mobile/src/public/createApp.ts
@@ -53,8 +53,8 @@ export function createApp<const tabScreenConfigs extends TabScreenConfig[]>(
   Config.DEEP_LINK_URL_SCHEME = config.deepLinkUrlScheme
   Config.APP_REGISTRY_NAME = config.registryName
   Config.ENABLED_NETWORK_IDS =
-    config.networks && Object.keys(config.networks).length > 0
-      ? Object.keys(config.networks).join(',')
+    config.networks?.enabledIds && config.networks.enabledIds.length > 0
+      ? config.networks?.enabledIds.join(',')
       : 'celo-mainnet,ethereum-mainnet,arbitrum-one,op-mainnet,base-mainnet'
 
   // TODO: map/handle the whole config

--- a/packages/@divvi/mobile/src/public/createApp.ts
+++ b/packages/@divvi/mobile/src/public/createApp.ts
@@ -53,8 +53,8 @@ export function createApp<const tabScreenConfigs extends TabScreenConfig[]>(
   Config.DEEP_LINK_URL_SCHEME = config.deepLinkUrlScheme
   Config.APP_REGISTRY_NAME = config.registryName
   Config.ENABLED_NETWORK_IDS =
-    config.networks?.enabledIds && config.networks.enabledIds.length > 0
-      ? config.networks?.enabledIds.join(',')
+    config.networks?.enabledNetworkIds && config.networks.enabledNetworkIds.length > 0
+      ? config.networks?.enabledNetworkIds.join(',')
       : 'celo-mainnet,ethereum-mainnet,arbitrum-one,op-mainnet,base-mainnet'
 
   // TODO: map/handle the whole config

--- a/packages/@divvi/mobile/src/public/createApp.ts
+++ b/packages/@divvi/mobile/src/public/createApp.ts
@@ -52,7 +52,10 @@ export function createApp<const tabScreenConfigs extends TabScreenConfig[]>(
   Config.ONBOARDING_FEATURES_ENABLED = getOnboardingFeatures(config)
   Config.DEEP_LINK_URL_SCHEME = config.deepLinkUrlScheme
   Config.APP_REGISTRY_NAME = config.registryName
-  Config.ENABLED_NETWORK_IDS = 'celo-mainnet,ethereum-mainnet,arbitrum-one,op-mainnet,base-mainnet'
+  Config.ENABLED_NETWORK_IDS =
+    config.networks && Object.keys(config.networks).length > 0
+      ? Object.keys(config.networks).join(',')
+      : 'celo-mainnet,ethereum-mainnet,arbitrum-one,op-mainnet,base-mainnet'
 
   // TODO: map/handle the whole config
 

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -178,7 +178,8 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
 
   //
   networks?: {
-    // For now just include key names, so apps can configure required networks
+    // For now just allow key names with an empty object, so apps can configure
+    // required networks.
     // TODO: we'll pass RPC urls, API urls, etc here
     [key in NetworkId]?: {}
   }

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -178,7 +178,9 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
 
   //
   networks?: {
+    // For now just include key names, so apps can configure required networks
     // TODO: we'll pass RPC urls, API urls, etc here
+    [key in NetworkId]?: {}
   }
 
   /**

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -178,7 +178,7 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
 
   //
   networks?: {
-    enabledIds?: NetworkId[]
+    enabledNetworkIds?: NetworkId[]
     // TODO: we'll pass RPC urls, API urls, etc here
   }
 

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -178,10 +178,8 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
 
   //
   networks?: {
-    // For now just allow key names with an empty object, so apps can configure
-    // required networks.
+    enabledIds?: NetworkId[]
     // TODO: we'll pass RPC urls, API urls, etc here
-    [key in NetworkId]?: {}
   }
 
   /**


### PR DESCRIPTION
### Description

Simplest change to allow configuring network ids to unblock cKash app

### Test plan

Manually by setting config.networks in apps/example and ensuring 

### Related issues

- Part of ENG-193

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
