### PR TITLE
refactor: get crowdin lang from getContent

### DIFF
--- a/packages/@divvi/mobile/src/i18n/saga.test.ts
+++ b/packages/@divvi/mobile/src/i18n/saga.test.ts
@@ -17,8 +17,15 @@ jest.mock('@crowdin/ota-client', () => {
   return function () {
     return {
       getManifestTimestamp: jest.fn(() => 123456),
-      getStringsByLocale: jest.fn(() => ({
-        someLang: { someNamespace: { someKey: 'someValue ' } },
+      getStringsByLocale: jest.fn((langCode: string) => {
+        if (langCode === 'en' || langCode === 'de') {
+          return { someNamespace: { someKey: 'someValue ' } }
+        }
+        throw new Error('Unsupported language')
+      }),
+      getContent: jest.fn(() => ({
+        en: ['main/locales/en-US/translation.json'],
+        de: ['main/locales/de/translation.json'],
       })),
     }
   }
@@ -36,7 +43,7 @@ describe('i18n sagas', () => {
   })
 
   it('handles fetching over the air translations', async () => {
-    const translations = { someLang: { someNamespace: { someKey: 'someValue ' } } }
+    const translations = { someNamespace: { someKey: 'someValue ' } }
     const timestamp = 123456
     const appVersion = '1.0.0'
     const mockedVersion = DeviceInfo.getVersion as jest.MockedFunction<typeof DeviceInfo.getVersion>


### PR DESCRIPTION
### Description

Follow up from #142 - with @jeanregisser we were questioning if there was any way to avoid a custom language mapping that we need to maintain. The `getContent` api seems like a good start, with the tradeoff that we need to make some assumption about the content value string format. It does not add an extra api request since the manifest is cached under the hood in Crowdin and is used by `getStringsByLocale` anyway.

Along the way of testing, I noticed that we are not invoking the OTA saga on app start anymore. Idk when this broke, but I added an explicit spawn in the i18n saga.

### Test plan

Tested that on app start and on app change language, OTA translations are fetched correctly and applied over the bundled translations when there is a difference.

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
