### PR TITLE
feat(navigate): add support for withdrawing by tokenId

### DIFF
--- a/apps/example/screens/PlaygroundScreen.tsx
+++ b/apps/example/screens/PlaygroundScreen.tsx
@@ -95,6 +95,10 @@ export default function PlaygroundScreen(_props: RootStackScreenProps<'Playgroun
             onPress: () => navigate('Add', { tokenId: 'celo-mainnet:native' }),
           },
           { label: 'Withdraw', onPress: () => navigate('Withdraw') },
+          {
+            label: 'Withdraw with tokenId',
+            onPress: () => navigate('Withdraw', { tokenId: 'celo-mainnet:native' }),
+          },
           { label: 'Tab Wallet', onPress: () => navigate('TabWallet') },
           {
             label: 'Custom Screen',

--- a/docs/reference/functions/navigate.md
+++ b/docs/reference/functions/navigate.md
@@ -10,7 +10,7 @@
 function navigate(...args): void
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/navigate.ts:61](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L61)
+Defined in: [packages/@divvi/mobile/src/public/navigate.ts:66](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L66)
 
 ## Parameters
 

--- a/docs/reference/type-aliases/StackParamList.md
+++ b/docs/reference/type-aliases/StackParamList.md
@@ -10,7 +10,7 @@
 type StackParamList = object
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/navigate.ts:31](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L31)
+Defined in: [packages/@divvi/mobile/src/public/navigate.ts:32](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/navigate.ts#L32)
 
 ## Type declaration
 
@@ -75,5 +75,9 @@ TabWallet: undefined
 ### Withdraw
 
 ```ts
-Withdraw: undefined
+Withdraw:
+  | {
+  tokenId: string;
+ }
+  | undefined;
 ```

--- a/packages/@divvi/mobile/src/public/navigate.test.ts
+++ b/packages/@divvi/mobile/src/public/navigate.test.ts
@@ -1,3 +1,4 @@
+import { getAppConfig } from 'src/appConfig'
 import { getMockStoreData } from 'test/utils'
 import { mockAaveArbUsdcTokenId, mockTokenBalances, mockUSDCTokenId } from 'test/values'
 import { CICOFlow, FiatExchangeFlow } from '../fiatExchanges/types'
@@ -101,6 +102,50 @@ describe('navigate', () => {
       expect(internalNavigate).toHaveBeenCalledWith(Screens.FiatExchangeCurrencyBottomSheet, {
         flow: FiatExchangeFlow.CashIn,
       })
+    })
+  })
+
+  describe('Withdraw', () => {
+    it('should navigate to FiatExchangeAmount for cash-out eligible token', () => {
+      const tokenId = mockUSDCTokenId
+      navigate('Withdraw', { tokenId })
+
+      expect(internalNavigate).toHaveBeenCalledWith(Screens.FiatExchangeAmount, {
+        tokenId,
+        flow: CICOFlow.CashOut,
+        tokenSymbol: 'USDC',
+      })
+    })
+
+    it('should navigate to FiatExchangeCurrencyBottomSheet for cash-out ineligible token', () => {
+      const tokenId = mockAaveArbUsdcTokenId
+      navigate('Withdraw', { tokenId })
+
+      expect(internalNavigate).toHaveBeenCalledWith(Screens.FiatExchangeCurrencyBottomSheet, {
+        flow: FiatExchangeFlow.CashOut,
+      })
+    })
+
+    it('should navigate to FiatExchangeCurrencyBottomSheet when no tokenId is provided and bidali is disabled', () => {
+      navigate('Withdraw')
+
+      expect(internalNavigate).toHaveBeenCalledWith(Screens.FiatExchangeCurrencyBottomSheet, {
+        flow: FiatExchangeFlow.CashOut,
+      })
+    })
+
+    it('should navigate to WithdrawSpend when no tokenId is provided and bidali is enabled', () => {
+      jest.mocked(getAppConfig).mockReturnValueOnce({
+        displayName: 'Test App',
+        deepLinkUrlScheme: 'testapp',
+        registryName: 'test',
+        experimental: {
+          bidali: { url: 'bidali' },
+        },
+      })
+      navigate('Withdraw')
+
+      expect(internalNavigate).toHaveBeenCalledWith(Screens.WithdrawSpend)
     })
   })
 


### PR DESCRIPTION
### Description

Also navigate to WithdrawSpend only if bidali is enabled

### Test plan

CI and manually with example app

### Related issues

- Part of ENG-193

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
