### PR TITLE
feat: config for nfts, token filters, network icon

### DIFF
--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -40,7 +40,7 @@ Defined in: [packages/@divvi/mobile/src/public/types.tsx:26](https://github.com/
 optional divviProtocol: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:249](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L249)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:251](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L251)
 
 #### protocolIds
 
@@ -70,7 +70,7 @@ referrerId: string
 optional experimental: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:202](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L202)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:204](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L204)
 
 Experimental features that may change or be removed in future versions.
 These features are not part of the stable configuration API and should be used with caution.
@@ -259,7 +259,7 @@ projectName: string
 optional features: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:153](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L153)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:155](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L155)
 
 #### cloudBackup?
 
@@ -353,7 +353,7 @@ optional locales: Partial<{
 }>;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:174](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L174)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:176](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L176)
 
 Optional copies overwrite. This field should contain the same language keys as @interxyz/mobile.
 TODO: Eventually, we want to make this fully type-safe (maybe with generics?)
@@ -366,7 +366,7 @@ TODO: Eventually, we want to make this fully type-safe (maybe with generics?)
 optional networks: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:191](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L191)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:193](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L193)
 
 #### enabledNetworkIds?
 
@@ -392,7 +392,7 @@ Defined in: [packages/@divvi/mobile/src/public/types.tsx:25](https://github.com/
 optional screens: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:136](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L136)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:138](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L138)
 
 #### custom()?
 

--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -40,7 +40,7 @@ Defined in: [packages/@divvi/mobile/src/public/types.tsx:26](https://github.com/
 optional divviProtocol: object;
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:247](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L247)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:249](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L249)
 
 #### protocolIds
 
@@ -107,6 +107,12 @@ optional bidali: object;
 url: string
 ```
 
+#### disableNfts?
+
+```ts
+optional disableNfts: boolean;
+```
+
 #### earn?
 
 ```ts
@@ -129,6 +135,12 @@ optional showSafetyScoreOnPoolCard: boolean;
 
 ```ts
 optional firebase: boolean;
+```
+
+#### hideCashInTokenFilters?
+
+```ts
+optional hideCashInTokenFilters: boolean;
 ```
 
 #### inviteFriends?

--- a/docs/reference/type-aliases/NetworkId.md
+++ b/docs/reference/type-aliases/NetworkId.md
@@ -22,4 +22,4 @@ type NetworkId =
   | 'base-sepolia'
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:256](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L256)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:258](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L258)

--- a/docs/reference/type-aliases/NetworkId.md
+++ b/docs/reference/type-aliases/NetworkId.md
@@ -22,4 +22,4 @@ type NetworkId =
   | 'base-sepolia'
 ```
 
-Defined in: [packages/@divvi/mobile/src/public/types.tsx:254](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L254)
+Defined in: [packages/@divvi/mobile/src/public/types.tsx:256](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L256)

--- a/packages/@divvi/mobile/src/components/TokenIcon.tsx
+++ b/packages/@divvi/mobile/src/components/TokenIcon.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import colors from 'src/styles/colors'
+import { getSupportedNetworkIds } from 'src/web3/utils'
 
 export enum IconSize {
   XXSMALL = 'xxsmall',
@@ -62,6 +63,7 @@ interface Props<T extends { imageUrl?: string; symbol?: string | never; networkI
 export default function TokenIcon<
   T extends { imageUrl?: string; symbol?: string | never; networkIconUrl?: string },
 >({ token, viewStyle, testID, size = IconSize.MEDIUM, showNetworkIcon = true }: Props<T>) {
+  showNetworkIcon = showNetworkIcon && getSupportedNetworkIds().length > 1
   const { tokenImageSize, networkImageSize, networkImagePosition, tokenTextSize } =
     IconSizeToStyle[size]
 

--- a/packages/@divvi/mobile/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
+++ b/packages/@divvi/mobile/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, within } from '@testing-library/react-native'
 import React from 'react'
 import { Provider } from 'react-redux'
+import { getAppConfig } from 'src/appConfig'
 import FiatExchangeCurrencyBottomSheet from 'src/fiatExchanges/FiatExchangeCurrencyBottomSheet'
 import { FiatExchangeFlow } from 'src/fiatExchanges/types'
 import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
@@ -149,6 +150,26 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
       expect(queryByTestId('FilterChipsCarousel')).toBeFalsy()
     }
   )
+
+  it('does not show filters if hideCashInTokenFilters is set', () => {
+    jest
+      .mocked(getAppConfig)
+      .mockReturnValueOnce({
+        displayName: 'Test App',
+        deepLinkUrlScheme: 'testapp',
+        registryName: 'test',
+        experimental: { hideCashInTokenFilters: true },
+      })
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{ flow: FiatExchangeFlow.CashIn }}
+        />
+      </Provider>
+    )
+    expect(queryByTestId('FilterChipsCarousel')).toBeFalsy()
+  })
 
   it('shows filters for cash in', () => {
     const { getByTestId, getByText } = render(

--- a/packages/@divvi/mobile/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
+++ b/packages/@divvi/mobile/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
@@ -9,6 +9,7 @@ import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 import {
+  mockAppConfig,
   mockCeloTokenId,
   mockCeurTokenId,
   mockCrealTokenId,
@@ -154,12 +155,7 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
   it('does not show filters if hideCashInTokenFilters is set', () => {
     jest
       .mocked(getAppConfig)
-      .mockReturnValueOnce({
-        displayName: 'Test App',
-        deepLinkUrlScheme: 'testapp',
-        registryName: 'test',
-        experimental: { hideCashInTokenFilters: true },
-      })
+      .mockReturnValueOnce({ ...mockAppConfig, experimental: { hideCashInTokenFilters: true } })
     const { queryByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator

--- a/packages/@divvi/mobile/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
+++ b/packages/@divvi/mobile/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
@@ -1,6 +1,7 @@
 import { BottomSheetScreenProps } from '@interaxyz/react-navigation-bottom-sheet'
 import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { getAppConfig } from 'src/appConfig'
 import { FilterChip } from 'src/components/FilterChipsCarousel'
 import TokenBottomSheet, { TokenPickerOrigin } from 'src/components/TokenBottomSheet'
 import { fetchFiatConnectProviders } from 'src/fiatconnect/slice'
@@ -35,7 +36,7 @@ function useFilterChips(
 
   const showUKCompliantVariant = getFeatureGate(StatsigFeatureGates.SHOW_UK_COMPLIANT_VARIANT)
 
-  if (flow !== FiatExchangeFlow.CashIn) {
+  if (flow !== FiatExchangeFlow.CashIn || getAppConfig().experimental?.hideCashInTokenFilters) {
     return []
   }
   const supportedNetworkIds = getSupportedNetworkIds()

--- a/packages/@divvi/mobile/src/nfts/saga.ts
+++ b/packages/@divvi/mobile/src/nfts/saga.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit'
 import { isPast, isToday } from 'date-fns'
+import { getAppConfig } from 'src/appConfig'
 import { celebratedNftFound, nftRewardReadyToDisplay } from 'src/home/actions'
 import { isSameNftContract } from 'src/home/celebration/utils'
 import { NftCelebrationStatus } from 'src/home/reducers'
@@ -27,6 +28,9 @@ import { call, put, select, spawn, take, takeLeading } from 'typed-redux-saga'
 const TAG = 'NftsSaga'
 
 async function fetchNftsForSupportedNetworks(address: string): Promise<NftWithNetworkId[]> {
+  if (getAppConfig().experimental?.disableNfts) {
+    return []
+  }
   const supportedNetworkIds = getSupportedNetworkIds()
   const nfts = await Promise.all(
     supportedNetworkIds.map(async (networkId) => {

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -121,6 +121,8 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
           iris?: ImageSourcePropType
         }
         backupAndRecoveryImages?: {
+          // TODO: consider renaming these to be more descriptive or switch to
+          // color parameterized svgs that are set based on theme colors
           walletSafe?: ImageSourcePropType
           cloudBackupEmail?: ImageSourcePropType
           recoveryPhraseEducation1?: ImageSourcePropType

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -239,6 +239,8 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
         }
       }
     }
+    disableNfts?: boolean
+    hideCashInTokenFilters?: boolean
   }
 
   divviProtocol?: {

--- a/packages/@divvi/mobile/src/tokens/AssetTabBar.test.tsx
+++ b/packages/@divvi/mobile/src/tokens/AssetTabBar.test.tsx
@@ -2,15 +2,18 @@ import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { AssetsEvents } from 'src/analytics/Events'
+import { getAppConfig } from 'src/appConfig'
 import Colors from 'src/styles/colors'
 import AssetTabBar from 'src/tokens/AssetTabBar'
 import { AssetTabType } from 'src/tokens/types'
+import { mockAppConfig } from 'test/values'
 
 describe('AssetTabBar', () => {
   const onChange = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.mocked(getAppConfig).mockReturnValue(mockAppConfig)
   })
 
   it('renders all items if positions is enabled', () => {
@@ -45,19 +48,76 @@ describe('AssetTabBar', () => {
     expect(tabItems[1].children[0]).toHaveStyle({ color: Colors.contentPrimary })
   })
 
-  it.each([
-    { tab: AssetTabType.Tokens, event: AssetsEvents.view_wallet_assets },
-    { tab: AssetTabType.Collectibles, event: AssetsEvents.view_collectibles },
-    { tab: AssetTabType.Positions, event: AssetsEvents.view_dapp_positions },
-  ])('selecting tab $tab fires analytics events and invokes on change', ({ tab, event }) => {
+  it('does not render collections if disableNfts is set', () => {
+    jest
+      .mocked(getAppConfig)
+      .mockReturnValue({ ...mockAppConfig, experimental: { disableNfts: true } })
     const { getAllByTestId } = render(
-      <AssetTabBar activeTab={AssetTabType.Tokens} onChange={onChange} displayPositions={true} />
+      <AssetTabBar activeTab={AssetTabType.Positions} onChange={onChange} displayPositions={true} />
     )
 
-    fireEvent.press(getAllByTestId('Assets/TabBarItem')[tab])
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
-    expect(AppAnalytics.track).toHaveBeenCalledWith(event)
-    expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenCalledWith(tab)
+    const tabItems = getAllByTestId('Assets/TabBarItem')
+    expect(tabItems).toHaveLength(2)
+    expect(tabItems[0]).toHaveTextContent('tokens')
+    expect(tabItems[0].children[0]).toHaveStyle({ color: Colors.contentSecondary })
+    expect(tabItems[1]).toHaveTextContent('dappPositions')
+    expect(tabItems[1].children[0]).toHaveStyle({ color: Colors.contentPrimary })
+  })
+
+  it('returns null if collects and positions are disabled', () => {
+    jest
+      .mocked(getAppConfig)
+      .mockReturnValue({ ...mockAppConfig, experimental: { disableNfts: true } })
+    const { toJSON } = render(
+      <AssetTabBar
+        activeTab={AssetTabType.Positions}
+        onChange={onChange}
+        displayPositions={false}
+      />
+    )
+    expect(toJSON()).toBeNull()
+  })
+
+  describe.each([
+    { testName: 'all tabs enabled', positions: true, collectibles: true },
+    { testName: 'collectibles disabled', positions: true, collectibles: false },
+    { testName: 'positions disabled', positions: false, collectibles: true },
+  ])('$testName', ({ positions, collectibles }) => {
+    const cases = [{ tab: AssetTabType.Tokens, event: AssetsEvents.view_wallet_assets, index: 0 }]
+    if (collectibles) {
+      cases.push({
+        tab: AssetTabType.Collectibles,
+        event: AssetsEvents.view_collectibles,
+        index: 1,
+      })
+    }
+    if (positions) {
+      cases.push({
+        tab: AssetTabType.Positions,
+        event: AssetsEvents.view_dapp_positions,
+        index: collectibles ? 2 : 1,
+      })
+    }
+    it.each(cases)(
+      'selecting tab $tab fires analytics events and invokes on change',
+      ({ tab, event, index }) => {
+        jest
+          .mocked(getAppConfig)
+          .mockReturnValue({ ...mockAppConfig, experimental: { disableNfts: !collectibles } })
+        const { getAllByTestId } = render(
+          <AssetTabBar
+            activeTab={AssetTabType.Tokens}
+            onChange={onChange}
+            displayPositions={positions}
+          />
+        )
+
+        fireEvent.press(getAllByTestId('Assets/TabBarItem')[index])
+        expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
+        expect(AppAnalytics.track).toHaveBeenCalledWith(event)
+        expect(onChange).toHaveBeenCalledTimes(1)
+        expect(onChange).toHaveBeenCalledWith(tab)
+      }
+    )
   })
 })

--- a/packages/@divvi/mobile/src/tokens/AssetTabBar.test.tsx
+++ b/packages/@divvi/mobile/src/tokens/AssetTabBar.test.tsx
@@ -83,24 +83,16 @@ describe('AssetTabBar', () => {
     { testName: 'collectibles disabled', positions: true, collectibles: false },
     { testName: 'positions disabled', positions: false, collectibles: true },
   ])('$testName', ({ positions, collectibles }) => {
-    const cases = [{ tab: AssetTabType.Tokens, event: AssetsEvents.view_wallet_assets, index: 0 }]
+    const cases = [{ tab: AssetTabType.Tokens, event: AssetsEvents.view_wallet_assets }]
     if (collectibles) {
-      cases.push({
-        tab: AssetTabType.Collectibles,
-        event: AssetsEvents.view_collectibles,
-        index: 1,
-      })
+      cases.push({ tab: AssetTabType.Collectibles, event: AssetsEvents.view_collectibles })
     }
     if (positions) {
-      cases.push({
-        tab: AssetTabType.Positions,
-        event: AssetsEvents.view_dapp_positions,
-        index: collectibles ? 2 : 1,
-      })
+      cases.push({ tab: AssetTabType.Positions, event: AssetsEvents.view_dapp_positions })
     }
     it.each(cases)(
       'selecting tab $tab fires analytics events and invokes on change',
-      ({ tab, event, index }) => {
+      ({ tab, event }) => {
         jest
           .mocked(getAppConfig)
           .mockReturnValue({ ...mockAppConfig, experimental: { disableNfts: !collectibles } })
@@ -112,6 +104,7 @@ describe('AssetTabBar', () => {
           />
         )
 
+        const index = cases.findIndex((c) => c.tab === tab)
         fireEvent.press(getAllByTestId('Assets/TabBarItem')[index])
         expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
         expect(AppAnalytics.track).toHaveBeenCalledWith(event)

--- a/packages/@divvi/mobile/src/tokens/AssetTabBar.tsx
+++ b/packages/@divvi/mobile/src/tokens/AssetTabBar.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { AssetsEvents } from 'src/analytics/Events'
+import { getAppConfig } from 'src/appConfig'
 import GradientBlock from 'src/components/GradientBlock'
 import Touchable from 'src/components/Touchable'
 import Colors from 'src/styles/colors'
@@ -26,12 +27,19 @@ export default function TabBar({
   const { t } = useTranslation()
 
   const items = useMemo(() => {
-    const items = [t('assets.tabBar.tokens'), t('assets.tabBar.collectibles')]
+    const items = [t('assets.tabBar.tokens')]
+    if (!getAppConfig().experimental?.disableNfts) {
+      items.push(t('assets.tabBar.collectibles'))
+    }
     if (displayPositions) {
       items.push(t('assets.tabBar.dappPositions'))
     }
     return items
   }, [t, displayPositions])
+
+  if (items.length <= 1) {
+    return null
+  }
 
   const handleSelectOption = (index: AssetTabType) => () => {
     AppAnalytics.track(

--- a/packages/@divvi/mobile/src/tokens/AssetTabBar.tsx
+++ b/packages/@divvi/mobile/src/tokens/AssetTabBar.tsx
@@ -27,12 +27,12 @@ export default function TabBar({
   const { t } = useTranslation()
 
   const items = useMemo(() => {
-    const items = [t('assets.tabBar.tokens')]
+    const items = [{ id: AssetTabType.Tokens, text: t('assets.tabBar.tokens') }]
     if (!getAppConfig().experimental?.disableNfts) {
-      items.push(t('assets.tabBar.collectibles'))
+      items.push({ id: AssetTabType.Collectibles, text: t('assets.tabBar.collectibles') })
     }
     if (displayPositions) {
-      items.push(t('assets.tabBar.dappPositions'))
+      items.push({ id: AssetTabType.Positions, text: t('assets.tabBar.dappPositions') })
     }
     return items
   }, [t, displayPositions])
@@ -41,15 +41,15 @@ export default function TabBar({
     return null
   }
 
-  const handleSelectOption = (index: AssetTabType) => () => {
+  const handleSelectOption = (id: AssetTabType) => () => {
     AppAnalytics.track(
       [
         AssetsEvents.view_wallet_assets,
         AssetsEvents.view_collectibles,
         AssetsEvents.view_dapp_positions,
-      ][index]
+      ][id]
     )
-    onChange(index)
+    onChange(id)
     vibrateInformative()
   }
 
@@ -62,22 +62,22 @@ export default function TabBar({
 
   return (
     <View style={[styles.container, { gap }]} testID="Assets/TabBar">
-      {items.map((value, index) => (
+      {items.map((item) => (
         <Touchable
           testID="Assets/TabBarItem"
-          key={value}
-          onPress={handleSelectOption(index)}
+          key={item.id}
+          onPress={handleSelectOption(item.id)}
           style={styles.touchable}
         >
           <>
             <Text
-              style={[index === activeTab ? styles.itemSelected : styles.item]}
+              style={[item.id === activeTab ? styles.itemSelected : styles.item]}
               numberOfLines={1}
             >
-              {value}
+              {item.text}
             </Text>
 
-            {index === activeTab && <GradientBlock style={styles.activeTabUnderline} />}
+            {item.id === activeTab && <GradientBlock style={styles.activeTabUnderline} />}
           </>
         </Touchable>
       ))}

--- a/packages/@divvi/mobile/src/transactions/api.ts
+++ b/packages/@divvi/mobile/src/transactions/api.ts
@@ -1,6 +1,12 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { getAppConfig } from 'src/appConfig'
 import { type LocalCurrencyCode } from 'src/localCurrency/consts'
-import { FEED_V2_INCLUDE_TYPES, type PageInfo, type TokenTransaction } from 'src/transactions/types'
+import {
+  FEED_V2_INCLUDE_TYPES,
+  FEED_V2_INCLUDE_TYPES_NO_NFT,
+  type PageInfo,
+  type TokenTransaction,
+} from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 import { getSupportedNetworkIds } from 'src/web3/utils'
 
@@ -27,12 +33,15 @@ export const transactionFeedV2Api = createApi({
       }
     >({
       query: ({ address, localCurrencyCode, endCursor: afterCursor }) => {
+        const includeTypes = getAppConfig().experimental?.disableNfts
+          ? FEED_V2_INCLUDE_TYPES_NO_NFT
+          : FEED_V2_INCLUDE_TYPES
         return {
           url: '',
           params: {
             address,
             networkIds: getSupportedNetworkIds().join(','),
-            includeTypes: FEED_V2_INCLUDE_TYPES.join(','),
+            includeTypes: includeTypes.join(','),
             localCurrencyCode,
             ...(afterCursor && { afterCursor }),
           },

--- a/packages/@divvi/mobile/src/transactions/feed/NftFeedItem.test.tsx
+++ b/packages/@divvi/mobile/src/transactions/feed/NftFeedItem.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { Provider } from 'react-redux'
+import { getAppConfig } from 'src/appConfig'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { RootState } from 'src/redux/reducers'
@@ -8,7 +9,7 @@ import NftFeedItem from 'src/transactions/feed/NftFeedItem'
 import { Fee, NetworkId, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 import { RecursivePartial, createMockStore } from 'test/utils'
-import { mockAccount, mockNftAllFields } from 'test/values'
+import { mockAccount, mockAppConfig, mockNftAllFields } from 'test/values'
 
 const MOCK_TX_HASH = '0x006b866d20452a24d1d90c7514422188cc7c5d873e2f1ed661ec3f810ad5331c'
 
@@ -89,5 +90,13 @@ describe('NftFeedItem', () => {
       nfts: [mockNftAllFields],
       networkId: NetworkId['celo-alfajores'],
     })
+  })
+
+  it('renders nothing if disableNfts is set', () => {
+    jest
+      .mocked(getAppConfig)
+      .mockReturnValueOnce({ ...mockAppConfig, experimental: { disableNfts: true } })
+    const { toJSON } = renderScreen({})
+    expect(toJSON()).toBeNull()
   })
 })

--- a/packages/@divvi/mobile/src/transactions/feed/NftFeedItem.tsx
+++ b/packages/@divvi/mobile/src/transactions/feed/NftFeedItem.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { HomeEvents } from 'src/analytics/Events'
+import { getAppConfig } from 'src/appConfig'
 import IconWithNetworkBadge from 'src/components/IconWithNetworkBadge'
 import Touchable from 'src/components/Touchable'
 import ImageErrorIcon from 'src/icons/ImageErrorIcon'
@@ -31,6 +32,10 @@ function NftFeedItem({ transaction }: Props) {
     AppAnalytics.track(HomeEvents.transaction_feed_item_select, {
       itemType: transaction.type,
     })
+  }
+
+  if (getAppConfig().experimental?.disableNfts) {
+    return null
   }
 
   return (

--- a/packages/@divvi/mobile/src/transactions/feed/TransactionFeedItemImage.test.tsx
+++ b/packages/@divvi/mobile/src/transactions/feed/TransactionFeedItemImage.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import TransactionFeedItemImage from 'src/transactions/feed/TransactionFeedItemImage'
+import { NetworkId, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
+import { getSupportedNetworkIds } from 'src/web3/utils'
+import { createMockStore } from 'test/utils'
+import { mockTokenBalances } from 'test/values'
+
+jest.mock('src/web3/utils')
+
+const store = createMockStore({
+  tokens: {
+    error: false,
+    tokenBalances: mockTokenBalances,
+  },
+})
+
+describe('TransactionFeedItemImage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest
+      .mocked(getSupportedNetworkIds)
+      .mockReturnValue([NetworkId['celo-alfajores'], NetworkId['ethereum-sepolia']])
+  })
+
+  it('renders icon with network badge', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <TransactionFeedItemImage
+          status={TransactionStatus.Complete}
+          transactionType={TokenTransactionTypeV2.SwapTransaction}
+          networkId={NetworkId['celo-alfajores']}
+        />
+      </Provider>
+    )
+
+    expect(getByTestId('NetworkBadge')).toBeTruthy()
+  })
+
+  it('renders icon without network badge if hideNetworkIcon is set', () => {
+    const { queryByTestId } = render(
+      <TransactionFeedItemImage
+        status={TransactionStatus.Complete}
+        transactionType={TokenTransactionTypeV2.SwapTransaction}
+        networkId={NetworkId['celo-alfajores']}
+        hideNetworkIcon={true}
+      />
+    )
+
+    expect(queryByTestId('NetworkBadge')).toBeFalsy()
+  })
+
+  it('renders icon without network badge if only one network is supported', () => {
+    jest.mocked(getSupportedNetworkIds).mockReturnValue([NetworkId['celo-alfajores']])
+    const { queryByTestId } = render(
+      <TransactionFeedItemImage
+        status={TransactionStatus.Complete}
+        transactionType={TokenTransactionTypeV2.SwapTransaction}
+        networkId={NetworkId['celo-alfajores']}
+      />
+    )
+
+    expect(queryByTestId('NetworkBadge')).toBeFalsy()
+  })
+})

--- a/packages/@divvi/mobile/src/transactions/feed/TransactionFeedItemImage.tsx
+++ b/packages/@divvi/mobile/src/transactions/feed/TransactionFeedItemImage.tsx
@@ -12,6 +12,7 @@ import { Recipient } from 'src/recipients/recipient'
 import Colors from 'src/styles/colors'
 import { NetworkId, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
+import { getSupportedNetworkIds } from 'src/web3/utils'
 
 const AVATAR_SIZE = 40
 
@@ -101,7 +102,7 @@ function TransactionFeedItemBaseImage(props: Props) {
 }
 
 function TransactionFeedItemImage(props: Props) {
-  if (props.hideNetworkIcon) {
+  if (props.hideNetworkIcon || getSupportedNetworkIds().length <= 1) {
     return <TransactionFeedItemBaseImage {...props} />
   }
 

--- a/packages/@divvi/mobile/src/transactions/types.ts
+++ b/packages/@divvi/mobile/src/transactions/types.ts
@@ -156,9 +156,7 @@ export enum TokenTransactionTypeV2 {
   EarnClaimReward = 'EARN_CLAIM_REWARD',
 }
 
-// Because the codebase supports both the old and new feed,
-// we need this list. But we can remove it once we delete the old feed.
-export const FEED_V2_INCLUDE_TYPES = [
+export const FEED_V2_INCLUDE_TYPES_NO_NFT = [
   TokenTransactionTypeV2.Received,
   TokenTransactionTypeV2.Sent,
   TokenTransactionTypeV2.NftReceived,
@@ -170,6 +168,14 @@ export const FEED_V2_INCLUDE_TYPES = [
   TokenTransactionTypeV2.Withdraw,
   TokenTransactionTypeV2.ClaimReward,
   TokenTransactionTypeV2.CrossChainDeposit,
+]
+
+// Because the codebase supports both the old and new feed,
+// we need this list. But we can remove it once we delete the old feed.
+export const FEED_V2_INCLUDE_TYPES = [
+  ...FEED_V2_INCLUDE_TYPES_NO_NFT,
+  TokenTransactionTypeV2.NftReceived,
+  TokenTransactionTypeV2.NftSent,
 ]
 
 // Can we optional the fields `transactionHash` and `block`?

--- a/packages/@divvi/mobile/src/transactions/types.ts
+++ b/packages/@divvi/mobile/src/transactions/types.ts
@@ -159,8 +159,6 @@ export enum TokenTransactionTypeV2 {
 export const FEED_V2_INCLUDE_TYPES_NO_NFT = [
   TokenTransactionTypeV2.Received,
   TokenTransactionTypeV2.Sent,
-  TokenTransactionTypeV2.NftReceived,
-  TokenTransactionTypeV2.NftSent,
   TokenTransactionTypeV2.SwapTransaction,
   TokenTransactionTypeV2.CrossChainSwapTransaction,
   TokenTransactionTypeV2.Approval,

--- a/packages/@divvi/mobile/test/values.ts
+++ b/packages/@divvi/mobile/test/values.ts
@@ -443,6 +443,7 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     symbol: 'cUSD',
     imageUrl:
       'https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png',
+    networkIconUrl: 'https://example.com/address-metadata/main/assets/tokens/CELO.png',
     name: 'Celo Dollar',
     decimals: 18,
     balance: '0',
@@ -2261,3 +2262,9 @@ export const mockStoreRewardReayWithDifferentNft = {
 }
 
 export const mockJumpstartAdddress = '0x7BF3fefE9881127553D23a8Cd225a2c2442c438C'
+
+export const mockAppConfig = {
+  displayName: 'Test App',
+  deepLinkUrlScheme: 'testapp',
+  registryName: 'test',
+}


### PR DESCRIPTION
### Description

- Add config for disabling NFTs
- Add config for hiding cash in token filters
- Hide network icon if number of enabled networks is 1

### Test plan

Unit tests. Manually by setting the following config:

```js
networks: {
  enabledNetworkIds: ['celo-mainnet'] // should hide network icons in tx feed and wallet tab
},
experimental: {
  disableNfts: true, // hide collectible tabs, don't show nfts in tx feed
  hideCashInTokenFilters: true // hide filters on cash in token selection bottom sheet
}
```

### Related issues

- Part of ENG-193

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
