### PR TITLE
feat: enable crowdin translations

### DIFF
--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -10,7 +10,7 @@
  */
 
 const CROWDIN_BRANCH = 'l10n/main'
-const CROWDIN_PR_USER = 'valora-bot-crowdin'
+const CROWDIN_PR_USER = 'divvi-bot-crowdin'
 
 const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(`locales\/.*\/translation\.json`)
 const DISALLOWED_UPDATED_FILES = ['locales/base/translation.json']

--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -12,8 +12,10 @@
 const CROWDIN_BRANCH = 'l10n/main'
 const CROWDIN_PR_USER = 'divvi-bot-crowdin'
 
-const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(`locales\/.*\/translation\.json`)
-const DISALLOWED_UPDATED_FILES = ['locales/base/translation.json']
+const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(
+  `packages/@divvi/mobile/locales/.*/translation\\.json`
+)
+const DISALLOWED_UPDATED_FILES = ['packages/@divvi/mobile/locales/base/translation.json']
 const enableAutomergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
   enablePullRequestAutoMerge(input: {
     pullRequestId: $pullRequestId,

--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -12,13 +12,8 @@
 const CROWDIN_BRANCH = 'l10n/main'
 const CROWDIN_PR_USER = 'valora-bot-crowdin'
 
-const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(
-  `locales\/.*\/translation\.json|ios/MobileStack\/.*\/InfoPlist.strings`
-)
-const DISALLOWED_UPDATED_FILES = [
-  'locales/base/translation.json',
-  'ios/MobileStack/Base.lproj/InfoPlist.strings',
-]
+const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(`locales\/.*\/translation\.json`)
+const DISALLOWED_UPDATED_FILES = ['locales/base/translation.json']
 const enableAutomergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
   enablePullRequestAutoMerge(input: {
     pullRequestId: $pullRequestId,

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
   # At 02:00 (UTC) daily
   # https://crontab.guru/#0_2_*_*_*
-  # 1 hour before the nightly build
-  # schedule:
-  #   - cron: '0 2 * * *'
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   automerge-crowdin-pr:

--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -3,8 +3,8 @@ name: Check translation files
 on:
   workflow_dispatch:
   # Run on pull request and merge queue
-  # pull_request:
-  # merge_group:
+  pull_request:
+  merge_group:
 
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
@@ -22,11 +22,9 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           files: |
-            locales/*/translation.json
-            ios/MobileStack/*.lproj/InfoPlist.strings
+            packages/@divvi/mobile/locales/*/translation.json
           files_ignore: |
-            locales/base/translation.json
-            ios/MobileStack/Base.lproj/InfoPlist.strings
+            packages/@divvi/mobile/locales/base/translation.json
       - name: Fail if translation files are changed
         if: ${{ (github.event_name != 'merge_group') && (github.head_ref != 'l10n/main') && (steps.changed-files.outputs.any_changed == 'true') }}
         run: |

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,5 @@
 pull_request_title: 'chore(l10n): update translations from Crowdin'
 files:
-  - source: /locales/base/*.json
-    translation: /locales/%locale%/%original_file_name%
+  - source: /packages/@divvi/mobile/locales/base/*.json
+    translation: /packages/@divvi/mobile/locales/%locale%/%original_file_name%
     type: i18next_json
-  - source: /ios/MobileStack/Base.lproj/InfoPlist.strings
-    translation: /ios/MobileStack/%osx_code%/%original_file_name%


### PR DESCRIPTION
### Description

This PR brings back the Crowdin translation sync. The sync config has been updated in [Crowdin](https://valorainc.crowdin.com/u/projects/2/integrations/system/github), as well as the crowdin.yml in this repo. 

### Test plan

The divvi-bot-owner will now submit PRs (e.g. #166 )

### Related issues

- Related to ENG-196

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
