### PR TITLE
feat(config): allow configuring some statsig defaults

### DIFF
--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -246,6 +246,10 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
     }
     disableNfts?: boolean
     hideCashInTokenFilters?: boolean
+    // statsig feature gate defaults
+    showPositions?: boolean
+    showImportTokensFlow?: boolean
+    showSwapTokenFilters?: boolean
   }
 
   divviProtocol?: {

--- a/packages/@divvi/mobile/src/statsig/constants.ts
+++ b/packages/@divvi/mobile/src/statsig/constants.ts
@@ -1,3 +1,4 @@
+import { getAppConfig } from 'src/appConfig'
 import type { FiatAccountSchemaCountryOverrides } from 'src/fiatconnect/types'
 import {
   StatsigDynamicConfigs,
@@ -7,14 +8,18 @@ import {
 } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
 
+const appConfig = getAppConfig()
+
 export const FeatureGates = {
-  [StatsigFeatureGates.SHOW_POSITIONS]: true,
+  [StatsigFeatureGates.SHOW_POSITIONS]: appConfig.experimental?.showPositions ?? true,
   [StatsigFeatureGates.SHOW_CLAIM_SHORTCUTS]: true,
   [StatsigFeatureGates.ALLOW_HOOKS_PREVIEW]: true,
   [StatsigFeatureGates.APP_REVIEW]: false,
-  [StatsigFeatureGates.SHOW_IMPORT_TOKENS_FLOW]: true,
+  [StatsigFeatureGates.SHOW_IMPORT_TOKENS_FLOW]:
+    appConfig.experimental?.showImportTokensFlow ?? true,
   [StatsigFeatureGates.SAVE_CONTACTS]: false,
-  [StatsigFeatureGates.SHOW_SWAP_TOKEN_FILTERS]: true,
+  [StatsigFeatureGates.SHOW_SWAP_TOKEN_FILTERS]:
+    appConfig.experimental?.showSwapTokenFilters ?? true,
   [StatsigFeatureGates.SHUFFLE_SWAP_TOKENS_ORDER]: false,
   [StatsigFeatureGates.SHOW_NFT_CELEBRATION]: false,
   [StatsigFeatureGates.SHOW_NFT_REWARD]: false,


### PR DESCRIPTION
### Description

Allow configuring statsig feature gates that need to have a different value from the default

### Test plan

CI, manually

### Related issues

- Part of ACT-193

### Backwards compatibility

Yes
