### PR TITLE
feat: extend functionality of `total-token-amount` version of `ReviewDetailsItem` component

### DIFF
--- a/packages/@divvi/mobile/src/components/ReviewTransaction.test.tsx
+++ b/packages/@divvi/mobile/src/components/ReviewTransaction.test.tsx
@@ -9,7 +9,7 @@ import { typeScale } from 'src/styles/fonts'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
 import { createMockStore } from 'test/utils'
-import { mockCeloTokenId, mockCusdTokenId, mockTokenBalances } from 'test/values'
+import { mockCeloTokenId, mockCeurTokenId, mockCusdTokenId, mockTokenBalances } from 'test/values'
 import {
   ReviewContent,
   ReviewDetailsItem,
@@ -157,8 +157,8 @@ describe('ReviewDetailsItem', () => {
     { fontSize: 'small', type: 'total-token-amount', font: typeScale.labelSemiBoldSmall },
     { fontSize: 'medium', type: 'total-token-amount', font: typeScale.labelSemiBoldMedium },
     { fontSize: undefined, type: 'total-token-amount', font: typeScale.labelSemiBoldMedium },
-  ] as (Pick<ReviewDetailsItemProps, 'fontSize' | 'type'> & { font: any })[])(
-    'renders correct font style for $fontSize $type',
+  ] as Array<Pick<ReviewDetailsItemProps, 'fontSize' | 'type'> & { font: any }>)(
+    'renders correct font style for $fontSize size $type',
     ({ fontSize, type, font }) => {
       const tree = render(
         <ReviewDetailsItem
@@ -166,6 +166,7 @@ describe('ReviewDetailsItem', () => {
           type={type}
           testID="DetailsItem"
           label="Label"
+          amounts={[]}
           {...({} as any)}
         />
       )
@@ -179,103 +180,282 @@ describe('ReviewDetailsItem', () => {
 describe('ReviewDetailsItemTotalValue', () => {
   const celoToken = mockTokenBalances[mockCeloTokenId] as unknown as TokenBalance
   const cUSDToken = mockTokenBalances[mockCusdTokenId] as unknown as TokenBalance
+  const cEURToken = mockTokenBalances[mockCeurTokenId] as unknown as TokenBalance
   it.each([
     {
-      tokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
-      tokenAmount: new BigNumber(10),
-      localAmount: new BigNumber(10),
-      feeTokenInfo: undefined,
-      feeTokenAmount: undefined,
-      feeLocalAmount: null,
+      amounts: [
+        {
+          tokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
+          tokenAmount: new BigNumber(10),
+          localAmount: new BigNumber(10),
+        },
+      ],
       title:
         'returns the token and fiat amount when fee info is missing and local price is available',
       result:
         'tokenAndLocalAmount, {"tokenAmount":"10.00","localAmount":"10.00","tokenSymbol":"CELO","localCurrencySymbol":"₱"}',
     },
     {
-      tokenInfo: { ...celoToken, priceUsd: null },
-      tokenAmount: new BigNumber(10),
-      localAmount: null,
-      feeTokenInfo: undefined,
-      feeTokenAmount: undefined,
-      feeLocalAmount: null,
+      amounts: [
+        {
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(10),
+          localAmount: null,
+        },
+      ],
       title:
         'returns only the token amount when fee info is missing and no local price is available',
       result: 'tokenAmount, {"tokenAmount":"10.00","tokenSymbol":"CELO"}',
     },
     {
-      tokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
-      tokenAmount: new BigNumber(10),
-      localAmount: new BigNumber(10),
-      feeTokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
-      feeTokenAmount: new BigNumber(0.5),
-      feeLocalAmount: new BigNumber(0.5),
+      amounts: [
+        {
+          tokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
+          tokenAmount: new BigNumber(10),
+          localAmount: new BigNumber(10),
+        },
+        {
+          tokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: new BigNumber(0.5),
+        },
+      ],
       title:
         'returns the token and local amount when the token and fee token are the same and local price is available',
       result:
         'tokenAndLocalAmount, {"tokenAmount":"10.50","localAmount":"10.50","tokenSymbol":"CELO","localCurrencySymbol":"₱"}',
     },
     {
-      tokenInfo: { ...celoToken, priceUsd: null },
-      tokenAmount: new BigNumber(10),
-      localAmount: null,
-      feeTokenInfo: { ...celoToken, priceUsd: null },
-      feeTokenAmount: new BigNumber(0.5),
-      feeLocalAmount: null,
+      amounts: [
+        {
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(10),
+          localAmount: null,
+        },
+        {
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: null,
+        },
+      ],
       title:
         "returns only the token amount when token and fee token are the same but they don't have local price",
       result: 'tokenAmount, {"tokenAmount":"10.50","tokenSymbol":"CELO"}',
     },
     {
-      tokenInfo: { ...cUSDToken, priceUsd: new BigNumber(1) },
-      tokenAmount: new BigNumber(10),
-      localAmount: new BigNumber(10),
-      feeTokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
-      feeTokenAmount: new BigNumber(0.5),
-      feeLocalAmount: new BigNumber(0.5),
+      amounts: [
+        {
+          tokenInfo: { ...cUSDToken, priceUsd: new BigNumber(1) },
+          tokenAmount: new BigNumber(10),
+          localAmount: new BigNumber(10),
+        },
+        {
+          tokenInfo: { ...celoToken, priceUsd: new BigNumber(1) },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: new BigNumber(0.5),
+        },
+      ],
       title:
         'returns only the local amount when token and fee token are different but local prices are available for both',
       result: 'localAmount, {"localAmount":"10.50","localCurrencySymbol":"₱"}',
     },
     {
-      tokenInfo: { ...cUSDToken, priceUsd: null },
-      tokenAmount: new BigNumber(10),
-      localAmount: null,
-      feeTokenInfo: { ...celoToken, priceUsd: null },
-      feeTokenAmount: new BigNumber(0.5),
-      feeLocalAmount: null,
+      amounts: [
+        {
+          tokenInfo: { ...cUSDToken, priceUsd: null },
+          tokenAmount: new BigNumber(10),
+          localAmount: null,
+        },
+        {
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: null,
+        },
+      ],
       title:
         'returns multiple token amounts when token and fee token are different and no local prices available',
       result:
-        'reviewTransaction.multipleTokensWithPlusSign, {"amount1":"10.00","symbol1":"cUSD","amount2":"0.50","symbol2":"CELO"}',
+        'tokenAmount, {"tokenAmount":"10","tokenSymbol":"cUSD"} + tokenAmount, {"tokenAmount":"0.5","tokenSymbol":"CELO"}',
     },
-  ])(
-    '$title',
-    ({
-      tokenInfo,
-      tokenAmount,
-      localAmount,
-      feeTokenInfo,
-      feeTokenAmount,
-      feeLocalAmount,
-      result,
-    }) => {
-      const tree = render(
-        <Provider store={createMockStore()}>
-          <View testID="Total">
-            <ReviewDetailsItemTotalValue
-              tokenInfo={tokenInfo}
-              feeTokenInfo={feeTokenInfo}
-              tokenAmount={tokenAmount}
-              localAmount={localAmount}
-              feeTokenAmount={feeTokenAmount}
-              feeLocalAmount={feeLocalAmount}
-              localCurrencySymbol={LocalCurrencySymbol.PHP}
-            />
-          </View>
-        </Provider>
-      )
-      expect(tree.getByTestId('Total')).toHaveTextContent(result)
-    }
-  )
+    {
+      amounts: [
+        {
+          tokenInfo: { ...cUSDToken, priceUsd: null },
+          tokenAmount: new BigNumber(10),
+          localAmount: new BigNumber(10),
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: new BigNumber(0.5),
+        },
+      ],
+      title:
+        'deducts the fee local amount from the input local amount when fiat price is available for both and shows the final fiat amount',
+      result: 'localAmount, {"localAmount":"9.50","localCurrencySymbol":"₱"}',
+    },
+    {
+      amounts: [
+        {
+          tokenInfo: { ...cUSDToken, priceUsd: null },
+          tokenAmount: new BigNumber(10),
+          localAmount: new BigNumber(10),
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: null,
+        },
+      ],
+      title:
+        'shows token amounts with a minus sign when fiat price is unavailable for any of the amounts',
+      result:
+        'tokenAmount, {"tokenAmount":"10","tokenSymbol":"cUSD"} - tokenAmount, {"tokenAmount":"0.5","tokenSymbol":"CELO"}',
+    },
+    {
+      amounts: [
+        {
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.0001),
+          localAmount: null,
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: null,
+        },
+      ],
+      title: 'shows negative token amount for the same token',
+      result: 'tokenAmount, {"tokenAmount":"- 0.50","tokenSymbol":"CELO"}',
+    },
+    {
+      amounts: [
+        {
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.1),
+          localAmount: new BigNumber(0.1),
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: new BigNumber(0.5),
+        },
+      ],
+      title: 'shows negative token and fiat amounts for the same token',
+      result:
+        'tokenAndLocalAmount, {"tokenAmount":"- 0.40","localAmount":"-0.40","tokenSymbol":"CELO","localCurrencySymbol":"₱"}',
+    },
+    {
+      amounts: [
+        {
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.1),
+          localAmount: new BigNumber(0.1),
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: new BigNumber(0.5),
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...cUSDToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.5),
+          localAmount: new BigNumber(0.5),
+        },
+        {
+          tokenInfo: { ...cEURToken, priceUsd: null },
+          tokenAmount: new BigNumber(0.3),
+          localAmount: new BigNumber(0.3),
+        },
+      ],
+      title: 'shows negative fiat amount for multiple different tokens',
+      result: 'localAmount, {"localAmount":"0.60","localCurrencySymbol":"- ₱"}',
+    },
+    {
+      amounts: [
+        {
+          tokenInfo: { ...cUSDToken, priceUsd: null },
+          tokenAmount: new BigNumber(10),
+          localAmount: new BigNumber(10),
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(1.5),
+          localAmount: new BigNumber(1.5),
+        },
+        {
+          tokenInfo: { ...cEURToken, priceUsd: null },
+          tokenAmount: new BigNumber(5.5),
+          localAmount: new BigNumber(5.5),
+        },
+        {
+          tokenInfo: { ...cEURToken, priceUsd: null },
+          tokenAmount: new BigNumber(1.5),
+          localAmount: new BigNumber(1.5),
+        },
+        {
+          tokenInfo: { ...cEURToken, priceUsd: null },
+          tokenAmount: new BigNumber(3),
+          localAmount: new BigNumber(3),
+        },
+      ],
+      title:
+        'properly sums all fiat amounts and shows the single final fiat amount that includes both addition and deduction',
+      result: 'localAmount, {"localAmount":"18.50","localCurrencySymbol":"₱"}',
+    },
+    {
+      amounts: [
+        {
+          tokenInfo: { ...cUSDToken, priceUsd: null },
+          tokenAmount: new BigNumber(10),
+          localAmount: null,
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...celoToken, priceUsd: null },
+          tokenAmount: new BigNumber(1.5),
+          localAmount: null,
+        },
+        {
+          tokenInfo: { ...cEURToken, priceUsd: null },
+          tokenAmount: new BigNumber(5.5),
+          localAmount: null,
+        },
+        {
+          isDeductible: true,
+          tokenInfo: { ...cEURToken, priceUsd: null },
+          tokenAmount: new BigNumber(1.5),
+          localAmount: null,
+        },
+        {
+          tokenInfo: { ...cEURToken, priceUsd: null },
+          tokenAmount: new BigNumber(3),
+          localAmount: null,
+        },
+      ],
+      title:
+        'properly sums amounts on a per-token basis and shows the sum of token amounts with plus or minus sign based on a final token amount for that token',
+      result:
+        'tokenAmount, {"tokenAmount":"10","tokenSymbol":"cUSD"} - tokenAmount, {"tokenAmount":"1.5","tokenSymbol":"CELO"} + tokenAmount, {"tokenAmount":"7","tokenSymbol":"cEUR"}',
+    },
+  ])('$title', ({ amounts, result }) => {
+    const tree = render(
+      <Provider store={createMockStore()}>
+        <View testID="Total">
+          <ReviewDetailsItemTotalValue
+            amounts={amounts}
+            localCurrencySymbol={LocalCurrencySymbol.PHP}
+          />
+        </View>
+      </Provider>
+    )
+    expect(tree.getByTestId('Total')).toHaveTextContent(result)
+  })
 })

--- a/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
+++ b/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { groupBy } from 'lodash'
 import React, { useMemo, type ReactNode } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View, type StyleProp, type TextStyle } from 'react-native'
@@ -8,7 +9,6 @@ import ContactCircle from 'src/components/ContactCircle'
 import CustomHeader from 'src/components/header/CustomHeader'
 import SkeletonPlaceholder from 'src/components/SkeletonPlaceholder'
 import { formatValueToDisplay } from 'src/components/TokenDisplay'
-import { APPROX_SYMBOL } from 'src/components/TokenEnterAmount'
 import Touchable from 'src/components/Touchable'
 import InfoIcon from 'src/icons/InfoIcon'
 import WalletIcon from 'src/icons/navigator/Wallet'
@@ -22,6 +22,17 @@ import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
+
+function sumAmounts(
+  amounts: FilteredAmount[],
+  type: keyof Pick<FilteredAmount, 'tokenAmount' | 'localAmount'>
+) {
+  let sum = new BigNumber(0)
+  for (const amount of amounts) {
+    sum = amount.isDeductible ? sum.minus(amount[type]!) : sum.plus(amount[type]!)
+  }
+  return sum
+}
 
 export function ReviewTransaction(props: {
   title: string
@@ -257,12 +268,14 @@ type ReviewDetailsItemTokenValueProps = {
 function ReviewDetailsItemTokenValue(props: ReviewDetailsItemTokenValueProps) {
   if (!props.tokenAmount) return null
 
+  const sign = props.tokenAmount.isNegative() ? '- ' : ''
+
   return (
     <Trans
       i18nKey={props.approx ? 'tokenAndLocalAmountApprox' : 'tokenAndLocalAmount'}
-      context={props.localAmount?.gt(0) ? undefined : 'noFiatPrice'}
+      context={props.localAmount ? undefined : 'noFiatPrice'}
       tOptions={{
-        tokenAmount: formatValueToDisplay(props.tokenAmount),
+        tokenAmount: `${sign}${formatValueToDisplay(props.tokenAmount.abs())}`,
         localAmount: props.localAmount ? formatValueToDisplay(props.localAmount) : '',
         tokenSymbol: props.tokenInfo?.symbol,
         localCurrencySymbol: props.localCurrencySymbol,
@@ -289,116 +302,125 @@ export function ReviewFooter(props: { children: ReactNode }) {
   return <View style={styles.reviewFooter}>{props.children}</View>
 }
 
-type ReviewDetailsItemTotalValueProps = {
-  approx?: boolean
-  tokenInfo: TokenBalance | undefined
-  feeTokenInfo: TokenBalance | undefined
-  tokenAmount: BigNumber | null
-  localAmount: BigNumber | null
-  feeTokenAmount: BigNumber | undefined
-  feeLocalAmount: BigNumber | null
-  localCurrencySymbol: LocalCurrencySymbol
+type Amount = {
+  isDeductible?: boolean
+  tokenInfo: TokenBalance | null | undefined
+  tokenAmount: BigNumber | null | undefined
+  localAmount: BigNumber | null | undefined
 }
 
+type FilteredAmount = {
+  isDeductible?: boolean
+  tokenInfo: TokenBalance
+  tokenAmount: BigNumber
+  localAmount: BigNumber | null | undefined
+}
+
+type ReviewDetailsItemTotalValueProps = {
+  approx?: boolean
+  localCurrencySymbol: LocalCurrencySymbol
+  amounts: Amount[]
+}
+
+/**
+ * This component doesn't do any memoization as the `amounts` array is always expected
+ * to be really small (< 10 items) so the overhead of running array operations on every
+ * re-render should be negligible.
+ */
 export function ReviewDetailsItemTotalValue({
   approx,
-  tokenInfo,
-  feeTokenInfo,
-  tokenAmount,
-  localAmount,
-  feeTokenAmount,
-  feeLocalAmount,
+  amounts,
   localCurrencySymbol,
 }: ReviewDetailsItemTotalValueProps) {
   const { t } = useTranslation()
-  const withApprox = approx ? `${APPROX_SYMBOL} ` : ''
 
-  // if there are not token info or token amount then it should not even be possible to get to the review screen
-  if (!tokenInfo || !tokenAmount) {
+  // filter out "broken" amounts with no token info or token amount
+  const filteredAmounts = amounts.filter(
+    (amount) => !!amount.tokenInfo && !!amount.tokenAmount
+  ) as FilteredAmount[]
+
+  // if all the amounts are "broken" (which should never happen) then don't return anything
+  if (filteredAmounts.length === 0) {
     return null
   }
 
-  // if there are no fees then just format token amount
-  if (!feeTokenInfo || !feeTokenAmount) {
-    // if fiat amount is availabke then show both token and fiat amounts
-    if (localAmount) {
-      return (
-        <ReviewDetailsItemTokenValue
-          approx={approx}
-          tokenAmount={tokenAmount}
-          localAmount={localAmount}
-          tokenInfo={tokenInfo}
-          localCurrencySymbol={localCurrencySymbol}
-        >
-          <Text style={styles.totalPlusFeesLocalAmount} />
-        </ReviewDetailsItemTokenValue>
-      )
-    }
+  /**
+   * At this point we have at least one token amount. There can be various variations of different
+   * tokens with variable availability of fiat prices. Based on that, we need to detect the kind of
+   * variation and format it accordingly.
+   */
+  const amountsGroupedByTokenId = groupBy(filteredAmounts, (amount) => amount.tokenInfo.tokenId)
+  const tokenIds = Object.keys(amountsGroupedByTokenId)
+  const sameToken = tokenIds.length === 1
+  const allTokensHaveLocalPrice = filteredAmounts.every((amount) => !!amount.localAmount)
 
-    // otherwise only show token amount
-
-    return withApprox
-      ? t('tokenAmountApprox', {
-          tokenAmount: formatValueToDisplay(tokenAmount),
-          tokenSymbol: tokenInfo.symbol,
-        })
-      : t('tokenAmount', {
-          tokenAmount: formatValueToDisplay(tokenAmount),
-          tokenSymbol: tokenInfo.symbol,
-        })
-  }
-
-  const sameToken = tokenInfo.tokenId === feeTokenInfo.tokenId
-  const haveLocalPrice = !!localAmount && !!feeLocalAmount
-
-  // if single token and have local price - return token and local amounts
-  if (sameToken && haveLocalPrice) {
+  /**
+   * If all the amounts are of the same token and we have a fiat price for it – then format the value
+   * to the format like "1.00 USDC ($1.00)".
+   */
+  if (sameToken && allTokensHaveLocalPrice) {
+    const tokenInfo = filteredAmounts[0].tokenInfo
+    const tokenAmount = sumAmounts(filteredAmounts, 'tokenAmount')
+    const localAmount = sumAmounts(filteredAmounts, 'localAmount')
     return (
       <ReviewDetailsItemTokenValue
         approx={approx}
-        tokenAmount={tokenAmount.plus(feeTokenAmount)}
-        localAmount={localAmount.plus(feeLocalAmount)}
         tokenInfo={tokenInfo}
         localCurrencySymbol={localCurrencySymbol}
+        tokenAmount={tokenAmount}
+        localAmount={localAmount}
       >
-        <Text style={styles.totalPlusFeesLocalAmount} />
+        <Text style={styles.totalLocalAmount} />
       </ReviewDetailsItemTokenValue>
     )
   }
 
-  // if single token but no local price - return token amount
-  if (sameToken && !haveLocalPrice) {
-    return withApprox
-      ? t('tokenAmountApprox', {
-          tokenAmount: formatValueToDisplay(tokenAmount.plus(feeTokenAmount)),
-          tokenSymbol: tokenInfo.symbol,
-        })
-      : t('tokenAmount', {
-          tokenAmount: formatValueToDisplay(tokenAmount.plus(feeTokenAmount)),
-          tokenSymbol: tokenInfo.symbol,
-        })
+  /**
+   * If all the amounts are of the same token but we don't have its fiat price available –
+   * then format the value to only show the sum of all token amounts like "1.00 USDC".
+   */
+  if (sameToken && !allTokensHaveLocalPrice) {
+    const tokenSymbol = filteredAmounts[0].tokenInfo.symbol
+    const tokenAmount = sumAmounts(filteredAmounts, 'tokenAmount')
+    const sign = tokenAmount.isNegative() ? '- ' : ''
+    const displayTokenAmount = `${sign}${formatValueToDisplay(tokenAmount.abs())}`
+    return approx
+      ? t('tokenAmountApprox', { tokenAmount: displayTokenAmount, tokenSymbol })
+      : t('tokenAmount', { tokenAmount: displayTokenAmount, tokenSymbol })
   }
 
-  // if multiple tokens and have local price - return local amount
-  if (!sameToken && haveLocalPrice) {
-    return withApprox
-      ? t('localAmountApprox', {
-          localAmount: formatValueToDisplay(localAmount.plus(feeLocalAmount)),
-          localCurrencySymbol,
-        })
-      : t('localAmount', {
-          localAmount: formatValueToDisplay(localAmount.plus(feeLocalAmount)),
-          localCurrencySymbol,
-        })
+  /**
+   * If there are multiple different tokens and we have fiat prices for all – then format the value
+   * to only show the sum of all fiat amounts like "$1.00"
+   */
+  if (!sameToken && allTokensHaveLocalPrice) {
+    const localAmount = sumAmounts(filteredAmounts, 'localAmount')
+    const sign = localAmount.isNegative() ? '- ' : ''
+    const displayLocalAmount = formatValueToDisplay(localAmount.abs())
+    const symbol = `${sign}${localCurrencySymbol}`
+    return approx
+      ? t('localAmountApprox', { localAmount: displayLocalAmount, localCurrencySymbol: symbol })
+      : t('localAmount', { localAmount: displayLocalAmount, localCurrencySymbol: symbol })
   }
 
-  // otherwise there are multiple tokens with no local prices so return multiple token amounts
-  return t('reviewTransaction.multipleTokensWithPlusSign', {
-    amount1: formatValueToDisplay(tokenAmount),
-    symbol1: tokenInfo.symbol,
-    amount2: formatValueToDisplay(feeTokenAmount),
-    symbol2: feeTokenInfo.symbol,
-  })
+  /**
+   * At this point we can be sure that we have multiple different tokens some/all of which don't
+   * have available fiat prices. In this case we have to do the following:
+   *   1. Sum all amounts on a per-token basis.
+   *   2. Show each token summed amount in a column in a format like "1.00 USDC + 0.0003 ETH - 1 CELO".
+   *      If the sum for a token is negative – show minus sign instead of plus.
+   */
+  return Object.values(amountsGroupedByTokenId)
+    .map((tokenAmounts, idx) => {
+      const sum = sumAmounts(tokenAmounts, 'tokenAmount')
+      const sign = sum.lt(0) ? '- ' : '+ '
+      const tokenAmount = t('tokenAmount', {
+        tokenAmount: sum.abs(),
+        tokenSymbol: tokenAmounts[0].tokenInfo.symbol,
+      })
+      return `${idx === 0 ? '' : sign}${tokenAmount}`
+    })
+    .join('\n')
 }
 
 export function ReviewParagraph(props: { children: ReactNode }) {
@@ -494,7 +516,7 @@ const styles = StyleSheet.create({
     height: '100%',
     width: '100%',
   },
-  totalPlusFeesLocalAmount: {
+  totalLocalAmount: {
     color: colors.contentSecondary,
   },
   paragraph: {

--- a/packages/@divvi/mobile/src/earn/EarnDepositConfirmationScreen.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnDepositConfirmationScreen.tsx
@@ -332,14 +332,20 @@ export default function EarnDepositConfirmationScreen({ route: { params } }: Pro
             testID="EarnDepositConfirmationTotal"
             type="total-token-amount"
             label={t('reviewTransaction.totalPlusFees')}
-            tokenInfo={inputTokenInfo}
-            feeTokenInfo={networkFee.token}
-            tokenAmount={depositAmount.tokenAmount}
-            localAmount={depositAmount.localAmount}
-            feeTokenAmount={networkFee.amount}
-            feeLocalAmount={networkFee.localAmount}
             localCurrencySymbol={localCurrencySymbol}
             onInfoPress={() => totalBottomSheetRef.current?.snapToIndex(0)}
+            amounts={[
+              {
+                tokenInfo: inputTokenInfo,
+                tokenAmount: depositAmount.tokenAmount,
+                localAmount: depositAmount.localAmount,
+              },
+              {
+                tokenInfo: networkFee.token,
+                tokenAmount: networkFee.amount,
+                localAmount: networkFee.localAmount,
+              },
+            ]}
           />
         </ReviewDetails>
       </ReviewContent>
@@ -446,13 +452,19 @@ export default function EarnDepositConfirmationScreen({ route: { params } }: Pro
             type="total-token-amount"
             testID="TotalInfoBottomSheet/Total"
             label={t('reviewTransaction.totalPlusFees')}
-            tokenInfo={inputTokenInfo}
-            feeTokenInfo={networkFee.token}
-            tokenAmount={depositAmount.tokenAmount}
-            localAmount={depositAmount.localAmount}
-            feeTokenAmount={networkFee.amount}
-            feeLocalAmount={networkFee.localAmount}
             localCurrencySymbol={localCurrencySymbol}
+            amounts={[
+              {
+                tokenInfo: inputTokenInfo,
+                tokenAmount: depositAmount.tokenAmount,
+                localAmount: depositAmount.localAmount,
+              },
+              {
+                tokenInfo: networkFee.token,
+                tokenAmount: networkFee.amount,
+                localAmount: networkFee.localAmount,
+              },
+            ]}
           />
         </InfoBottomSheetContentBlock>
       </InfoBottomSheet>

--- a/packages/@divvi/mobile/src/send/SendConfirmation.tsx
+++ b/packages/@divvi/mobile/src/send/SendConfirmation.tsx
@@ -217,14 +217,16 @@ export default function SendConfirmation({ route: { params } }: Props) {
             type="total-token-amount"
             label={t('reviewTransaction.totalPlusFees')}
             isLoading={prepareTransactionLoading}
-            onInfoPress={() => totalBottomSheetRef.current?.snapToIndex(0)}
-            tokenInfo={tokenInfo}
-            feeTokenInfo={feeTokenInfo}
-            tokenAmount={tokenAmount}
-            localAmount={localAmount}
-            feeTokenAmount={maxFeeAmount}
-            feeLocalAmount={localMaxFeeAmount}
             localCurrencySymbol={localCurrencySymbol}
+            onInfoPress={() => totalBottomSheetRef.current?.snapToIndex(0)}
+            amounts={[
+              { tokenInfo, tokenAmount, localAmount },
+              {
+                tokenInfo: feeTokenInfo,
+                tokenAmount: tokenEstimatedFeeAmount,
+                localAmount: localEstimatedFeeAmount,
+              },
+            ]}
           />
         </ReviewDetails>
       </ReviewContent>
@@ -297,13 +299,15 @@ export default function SendConfirmation({ route: { params } }: Props) {
             fontSize="small"
             type="total-token-amount"
             label={t('reviewTransaction.totalPlusFees')}
-            tokenInfo={tokenInfo}
-            feeTokenInfo={feeTokenInfo}
-            tokenAmount={tokenAmount}
-            localAmount={localAmount}
-            feeTokenAmount={maxFeeAmount}
-            feeLocalAmount={localMaxFeeAmount}
             localCurrencySymbol={localCurrencySymbol}
+            amounts={[
+              { tokenInfo, tokenAmount, localAmount },
+              {
+                tokenInfo: feeTokenInfo,
+                tokenAmount: tokenEstimatedFeeAmount,
+                localAmount: localEstimatedFeeAmount,
+              },
+            ]}
           />
         </InfoBottomSheetContentBlock>
       </InfoBottomSheet>


### PR DESCRIPTION
### Description
While working on the new earn withdrawal confirmation screen as per the design changes there appeared to be two issues with the current implementation of `ReviewDetailsItem` component which is used to show total amount for the transaction:
- there is no way to deduct fee from the amount instead of adding it to the amount
- there is no way to add more token amounts to the total (e.g. to include claimed rewards to the total).
For this case there was a need to change the implementation of the `total-token-amount` type of `ReviewDetailsItem` component to allow these calculations.

Initially I considered to just extend the props to allow all the possible calculation variations but there are too many amounts that could be added:
- swap app fee
- cross chain fee
- multiple claimed rewards

So it felt a lot more natural to lean to a more automated approach using dynamic array of amounts.

There is no memoization in `ReviewDetailsItem` for the following reasons:
- the `amounts` array is expected to always be tiny (between 1-5 items in 99% of cases) so the overhead of re-running the loop functions can be considered negligible
- memoization would require the consumer components to always memoize the passed array, which we definitely can forget to do (or forget to make it type-safe).

There is also no memoization in the consumer components as using `useMemo` outside of the scope of JSX (meaning above the `return` statement) to declare the array of amounts would require the type for the array to be exported from `ReviewTransaction.tsx` file in order to still keep the type-safety. It feels unnecessary and redundant (in terms of extra boilerplate) considering the array is always gonna be small and we can get the type-safety simply from defining the array right on the JSX level.

I've added some extra comments to the `ReviewDetailsItemTotalValue` component to better explain the logic of the component so it is more clear what the rendering conditions for each format are.

<!-- A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR? -->

### Test plan
Adjusted existing tests to the new props.

### Related issues

- Relates to [ENG-223](https://linear.app/valora/issue/ENG-223/%5Bwallet%5D-add-new-reviewtransaction-component-to-earnconfirmationscreen)

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
