### PR TITLE
feat: add aave to supported Divvi protocols

### DIFF
--- a/docs/reference/interfaces/PublicAppConfig.md
+++ b/docs/reference/interfaces/PublicAppConfig.md
@@ -46,6 +46,7 @@ Defined in: [packages/@divvi/mobile/src/public/types.tsx:258](https://github.com
 
 ```ts
 protocolIds: (
+  | "aave"
   | "aerodrome"
   | "allbridge"
   | "beefy"

--- a/packages/@divvi/mobile/src/divviProtocol/constants.ts
+++ b/packages/@divvi/mobile/src/divviProtocol/constants.ts
@@ -3,6 +3,7 @@ import { Address } from 'viem'
 export const REGISTRY_CONTRACT_ADDRESS: Address = '0xba9655677f4e42dd289f5b7888170bc0c7da8cdc'
 
 export const supportedProtocolIds = [
+  'aave',
   'aerodrome',
   'allbridge',
   'beefy',

--- a/packages/@divvi/mobile/test/RootStateSchema.json
+++ b/packages/@divvi/mobile/test/RootStateSchema.json
@@ -4637,7 +4637,7 @@
                     "$ref": "#/definitions/AppState"
                 },
                 "divviRegistrations": {
-                    "$ref": "#/definitions/{\"celo-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"celo-alfajores\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-one\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-amoy\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;}"
+                    "$ref": "#/definitions/{\"celo-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"celo-alfajores\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-one\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-amoy\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;}"
                 },
                 "googleMobileServicesAvailable": {
                     "type": "boolean"
@@ -6686,12 +6686,13 @@
             ],
             "type": "object"
         },
-        "{\"celo-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"celo-alfajores\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-one\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-amoy\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-mainnet\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-sepolia\"?:(\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;}": {
+        "{\"celo-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"celo-alfajores\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"ethereum-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-one\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"arbitrum-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"op-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"polygon-pos-amoy\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-mainnet\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;\"base-sepolia\"?:(\"aave\"|\"aerodrome\"|\"allbridge\"|\"beefy\"|\"celo\"|\"fonbnk\"|\"mento\"|\"somm\"|\"vana\")[]|undefined;}": {
             "additionalProperties": false,
             "properties": {
                 "arbitrum-one": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6708,6 +6709,7 @@
                 "arbitrum-sepolia": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6724,6 +6726,7 @@
                 "base-mainnet": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6740,6 +6743,7 @@
                 "base-sepolia": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6756,6 +6760,7 @@
                 "celo-alfajores": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6772,6 +6777,7 @@
                 "celo-mainnet": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6788,6 +6794,7 @@
                 "ethereum-mainnet": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6804,6 +6811,7 @@
                 "ethereum-sepolia": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6820,6 +6828,7 @@
                 "op-mainnet": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6836,6 +6845,7 @@
                 "op-sepolia": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6852,6 +6862,7 @@
                 "polygon-pos-amoy": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",
@@ -6868,6 +6879,7 @@
                 "polygon-pos-mainnet": {
                     "items": {
                         "enum": [
+                            "aave",
                             "aerodrome",
                             "allbridge",
                             "beefy",


### PR DESCRIPTION
### Description

We want to add Valora as a referrer to Aave.

### Test plan

- CI passes

### Related issues

- Part of ENG-205

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
