### PR TITLE
feat!: don't expose testnets for now

### DIFF
--- a/docs/reference/type-aliases/NetworkId.md
+++ b/docs/reference/type-aliases/NetworkId.md
@@ -9,17 +9,11 @@
 ```ts
 type NetworkId =
   | 'celo-mainnet'
-  | 'celo-alfajores'
   | 'ethereum-mainnet'
-  | 'ethereum-sepolia'
   | 'arbitrum-one'
-  | 'arbitrum-sepolia'
   | 'op-mainnet'
-  | 'op-sepolia'
   | 'polygon-pos-mainnet'
-  | 'polygon-pos-amoy'
   | 'base-mainnet'
-  | 'base-sepolia'
 ```
 
 Defined in: [packages/@divvi/mobile/src/public/types.tsx:268](https://github.com/divvi-xyz/divvi-mobile/blob/main/packages/@divvi/mobile/src/public/types.tsx#L268)

--- a/packages/@divvi/mobile/src/public/getPublicClient.test.ts
+++ b/packages/@divvi/mobile/src/public/getPublicClient.test.ts
@@ -1,13 +1,19 @@
 import { getPublicClient } from './getPublicClient'
 
+// TODO: remove this once when remove DEFAULT_TESTNET
+jest.mock('../config', () => ({
+  ...jest.requireActual('../config'),
+  DEFAULT_TESTNET: 'mainnet',
+}))
+
 describe('getPublicClient', () => {
   it('should return the correct public client', () => {
-    const publicClient = getPublicClient({ networkId: 'celo-alfajores' })
+    const publicClient = getPublicClient({ networkId: 'celo-mainnet' })
     expect(publicClient).toBeDefined()
   })
 
   it('should throw an error if the networkId is not yet supported', () => {
     // Tests only use testnet networks, in the future we'll be able to remove this check
-    expect(() => getPublicClient({ networkId: 'celo-mainnet' })).toThrow()
+    expect(() => getPublicClient({ networkId: 'celo-alfajores' as any })).toThrow()
   })
 })

--- a/packages/@divvi/mobile/src/public/getPublicClient.test.ts
+++ b/packages/@divvi/mobile/src/public/getPublicClient.test.ts
@@ -1,6 +1,6 @@
 import { getPublicClient } from './getPublicClient'
 
-// TODO: remove this once when remove DEFAULT_TESTNET
+// TODO: remove this when we remove DEFAULT_TESTNET
 jest.mock('../config', () => ({
   ...jest.requireActual('../config'),
   DEFAULT_TESTNET: 'mainnet',

--- a/packages/@divvi/mobile/src/public/getWalletClient.test.ts
+++ b/packages/@divvi/mobile/src/public/getWalletClient.test.ts
@@ -4,7 +4,7 @@ import { getWalletClient } from './getWalletClient'
 
 jest.mock('../web3/contracts')
 
-// TODO: remove this once when remove DEFAULT_TESTNET
+// TODO: remove this when we remove DEFAULT_TESTNET
 jest.mock('../config', () => ({
   ...jest.requireActual('../config'),
   DEFAULT_TESTNET: 'mainnet',

--- a/packages/@divvi/mobile/src/public/getWalletClient.test.ts
+++ b/packages/@divvi/mobile/src/public/getWalletClient.test.ts
@@ -1,8 +1,14 @@
-import { celoAlfajores } from 'viem/chains'
+import { celo } from 'viem/chains'
 import { getViemWallet } from '../web3/contracts'
 import { getWalletClient } from './getWalletClient'
 
 jest.mock('../web3/contracts')
+
+// TODO: remove this once when remove DEFAULT_TESTNET
+jest.mock('../config', () => ({
+  ...jest.requireActual('../config'),
+  DEFAULT_TESTNET: 'mainnet',
+}))
 
 describe('getWalletClient', () => {
   beforeEach(() => {
@@ -12,13 +18,13 @@ describe('getWalletClient', () => {
   })
 
   it('should return the correct wallet client', async () => {
-    const walletClient = await getWalletClient({ networkId: 'celo-alfajores' })
+    const walletClient = await getWalletClient({ networkId: 'celo-mainnet' })
     expect(walletClient).toBeDefined()
-    expect(getViemWallet).toHaveBeenCalledWith(celoAlfajores)
+    expect(getViemWallet).toHaveBeenCalledWith(celo)
   })
 
   it('should throw an error if the networkId is not yet supported', async () => {
     // Tests only use testnet networks, in the future we'll be able to remove this check
-    await expect(getWalletClient({ networkId: 'celo-mainnet' })).rejects.toThrow()
+    await expect(getWalletClient({ networkId: 'celo-alfajores' as any })).rejects.toThrow()
   })
 })

--- a/packages/@divvi/mobile/src/public/hooks/usePublicClient.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/usePublicClient.test.ts
@@ -16,9 +16,9 @@ describe('usePublicClient', () => {
   })
 
   it('should return public client for the given networkId', () => {
-    const { result } = renderHook(() => usePublicClient({ networkId: 'celo-alfajores' }))
+    const { result } = renderHook(() => usePublicClient({ networkId: 'celo-mainnet' }))
 
-    expect(getPublicClient).toHaveBeenCalledWith({ networkId: 'celo-alfajores' })
+    expect(getPublicClient).toHaveBeenCalledWith({ networkId: 'celo-mainnet' })
     expect(result.current).toBe(mockPublicClient)
   })
 })

--- a/packages/@divvi/mobile/src/public/hooks/useWalletClient.test.ts
+++ b/packages/@divvi/mobile/src/public/hooks/useWalletClient.test.ts
@@ -16,7 +16,7 @@ describe('useWalletClient', () => {
     const mockWalletClient = {} as any
     mockGetWalletClient.mockResolvedValueOnce(mockWalletClient)
 
-    const { result } = renderHook(() => useWalletClient({ networkId: 'celo-alfajores' }))
+    const { result } = renderHook(() => useWalletClient({ networkId: 'celo-mainnet' }))
 
     await waitFor(() => expect(result.current.data).toEqual(mockWalletClient))
     expect(mockGetWalletClient).toHaveBeenCalledTimes(1)
@@ -27,7 +27,7 @@ describe('useWalletClient', () => {
     const mockError = new Error('Failed to get wallet client')
     mockGetWalletClient.mockRejectedValueOnce(mockError)
 
-    const { result } = renderHook(() => useWalletClient({ networkId: 'celo-alfajores' }))
+    const { result } = renderHook(() => useWalletClient({ networkId: 'celo-mainnet' }))
 
     await waitFor(() => expect(result.current.error).toBe(mockError))
     expect(result.current.status).toEqual('error')

--- a/packages/@divvi/mobile/src/public/prepareTransactions.test.ts
+++ b/packages/@divvi/mobile/src/public/prepareTransactions.test.ts
@@ -31,7 +31,7 @@ describe('prepareTransactions', () => {
   })
 
   it('should correctly prepare transactions', async () => {
-    const feeCurrencies = feeCurrenciesSelector(store.getState(), NetworkId['celo-alfajores'])
+    const feeCurrencies = feeCurrenciesSelector(store.getState(), NetworkId['celo-mainnet'])
     const mockPrepareResult = { type: 'possible' } as any
 
     jest.mocked(internalPrepareTransactions).mockResolvedValue(mockPrepareResult)
@@ -46,7 +46,7 @@ describe('prepareTransactions', () => {
     ]
 
     const result = await prepareTransactions({
-      networkId: 'celo-alfajores',
+      networkId: 'celo-mainnet',
       transactionRequests: txRequests,
     })
 
@@ -70,7 +70,7 @@ describe('prepareTransactions', () => {
   it('should throw if no wallet address is found', async () => {
     mockStore.getState.mockImplementation(() => getMockStoreData({ web3: { account: null } }))
     await expect(
-      prepareTransactions({ networkId: 'celo-alfajores', transactionRequests: [] })
+      prepareTransactions({ networkId: 'celo-mainnet', transactionRequests: [] })
     ).rejects.toThrow('Wallet address not found')
   })
 })

--- a/packages/@divvi/mobile/src/public/types.tsx
+++ b/packages/@divvi/mobile/src/public/types.tsx
@@ -267,14 +267,8 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
 // TODO: we'll use this type throughout the framework once we're able to make bigger refactor, eliminating the current NetworkId enum
 export type NetworkId =
   | 'celo-mainnet'
-  | 'celo-alfajores'
   | 'ethereum-mainnet'
-  | 'ethereum-sepolia'
   | 'arbitrum-one'
-  | 'arbitrum-sepolia'
   | 'op-mainnet'
-  | 'op-sepolia'
   | 'polygon-pos-mainnet'
-  | 'polygon-pos-amoy'
   | 'base-mainnet'
-  | 'base-sepolia'


### PR DESCRIPTION
### Description

The framework currently only works for mainnet/production networks.
So it's preferable not to expose testnets for now.

### Test plan

- Tests pass

### Related issues

N/A

### Backwards compatibility

No, but no (known) divvi apps were using testnets.

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
