### PR TITLE
feat: add review details section to `EarnWithdrawConfirmationScreen`

### DIFF
--- a/packages/@divvi/mobile/locales/base/translation.json
+++ b/packages/@divvi/mobile/locales/base/translation.json
@@ -2877,6 +2877,7 @@
   "reviewTransaction": {
     "title": "Review Send",
     "totalPlusFees": "Total Plus Fees",
+    "totalLessFees": "Total Less Fees",
     "multipleTokensWithPlusSign": "≈ {{amount1}} {{symbol1}} + {{amount2}} {{symbol2}}"
   },
   "maxNetworkFee": "Max Network Fee",

--- a/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
+++ b/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
@@ -319,7 +319,7 @@ type FilteredAmount = {
 type ReviewDetailsItemTotalValueProps = {
   approx?: boolean
   localCurrencySymbol: LocalCurrencySymbol
-  amounts: Amount[]
+  amounts: Array<Amount | undefined | false>
 }
 
 /**
@@ -336,7 +336,7 @@ export function ReviewDetailsItemTotalValue({
 
   // filter out "broken" amounts with no token info or token amount
   const filteredAmounts = amounts.filter(
-    (amount) => !!amount.tokenInfo && !!amount.tokenAmount
+    (amount) => !!amount && !!amount.tokenInfo && !!amount.tokenAmount
   ) as FilteredAmount[]
 
   // if all the amounts are "broken" (which should never happen) then don't return anything

--- a/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
+++ b/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
@@ -23,10 +23,7 @@ import variables from 'src/styles/variables'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
 
-function sumAmounts(
-  amounts: FilteredAmount[],
-  type: keyof Pick<FilteredAmount, 'tokenAmount' | 'localAmount'>
-) {
+function sumAmounts(amounts: Amount[], type: keyof Pick<Amount, 'tokenAmount' | 'localAmount'>) {
   let sum = new BigNumber(0)
   for (const amount of amounts) {
     sum = amount.isDeductible ? sum.minus(amount[type]!) : sum.plus(amount[type]!)
@@ -302,24 +299,31 @@ export function ReviewFooter(props: { children: ReactNode }) {
   return <View style={styles.reviewFooter}>{props.children}</View>
 }
 
-type Amount = {
+type MaybeAmount = {
   isDeductible?: boolean
   tokenInfo: TokenBalance | null | undefined
   tokenAmount: BigNumber | null | undefined
   localAmount: BigNumber | null | undefined
 }
 
-type FilteredAmount = {
-  isDeductible?: boolean
-  tokenInfo: TokenBalance
-  tokenAmount: BigNumber
-  localAmount: BigNumber | null | undefined
-}
+type Amount = MaybeAmount & { tokenInfo: TokenBalance; tokenAmount: BigNumber }
 
 type ReviewDetailsItemTotalValueProps = {
   approx?: boolean
   localCurrencySymbol: LocalCurrencySymbol
-  amounts: Array<Amount | undefined | false>
+  amounts: Amount[]
+}
+
+/**
+ * Filters and returns an array of valid Amounts, removing falsy values, and ensuring each Amount
+ * has valid tokenInfo and tokenAmount properties.
+ */
+export function buildAmounts(
+  maybeAmounts: Array<MaybeAmount | undefined | false | null>
+): Amount[] {
+  return maybeAmounts.filter(
+    (amount): amount is Amount => !!amount && !!amount.tokenInfo && !!amount.tokenAmount
+  )
 }
 
 /**
@@ -337,7 +341,7 @@ export function ReviewDetailsItemTotalValue({
   // filter out "broken" amounts with no token info or token amount
   const filteredAmounts = amounts.filter(
     (amount) => !!amount && !!amount.tokenInfo && !!amount.tokenAmount
-  ) as FilteredAmount[]
+  ) as Amount[]
 
   // if all the amounts are "broken" (which should never happen) then don't return anything
   if (filteredAmounts.length === 0) {

--- a/packages/@divvi/mobile/src/earn/EarnDepositConfirmationScreen.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnDepositConfirmationScreen.tsx
@@ -16,6 +16,7 @@ import InfoBottomSheet, {
   InfoBottomSheetParagraph,
 } from 'src/components/InfoBottomSheet'
 import {
+  buildAmounts,
   ReviewContent,
   ReviewDetails,
   ReviewDetailsItem,
@@ -334,7 +335,7 @@ export default function EarnDepositConfirmationScreen({ route: { params } }: Pro
             label={t('reviewTransaction.totalPlusFees')}
             localCurrencySymbol={localCurrencySymbol}
             onInfoPress={() => totalBottomSheetRef.current?.snapToIndex(0)}
-            amounts={[
+            amounts={buildAmounts([
               {
                 tokenInfo: inputTokenInfo,
                 tokenAmount: depositAmount.tokenAmount,
@@ -345,7 +346,7 @@ export default function EarnDepositConfirmationScreen({ route: { params } }: Pro
                 tokenAmount: networkFee.amount,
                 localAmount: networkFee.localAmount,
               },
-            ]}
+            ])}
           />
         </ReviewDetails>
       </ReviewContent>
@@ -453,7 +454,7 @@ export default function EarnDepositConfirmationScreen({ route: { params } }: Pro
             testID="TotalInfoBottomSheet/Total"
             label={t('reviewTransaction.totalPlusFees')}
             localCurrencySymbol={localCurrencySymbol}
-            amounts={[
+            amounts={buildAmounts([
               {
                 tokenInfo: inputTokenInfo,
                 tokenAmount: depositAmount.tokenAmount,
@@ -464,7 +465,7 @@ export default function EarnDepositConfirmationScreen({ route: { params } }: Pro
                 tokenAmount: networkFee.amount,
                 localAmount: networkFee.localAmount,
               },
-            ]}
+            ])}
           />
         </InfoBottomSheetContentBlock>
       </InfoBottomSheet>

--- a/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
@@ -6,6 +6,7 @@ import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
 import { openUrl } from 'src/app/actions'
 import {
+  buildAmounts,
   ReviewContent,
   ReviewDetails,
   ReviewDetailsItem,
@@ -238,7 +239,7 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
             label={t('reviewTransaction.totalLessFees')}
             localCurrencySymbol={localCurrencySymbol}
             isLoading={preparedTransaction.loading}
-            amounts={[
+            amounts={buildAmounts([
               params.mode !== 'claim-rewards' && {
                 tokenInfo: withdraw.depositToken,
                 tokenAmount: withdraw.tokenAmount,
@@ -251,7 +252,7 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
                 localAmount: networkFee?.localAmount,
               },
               ...rewards.tokens,
-            ]}
+            ])}
           />
         </ReviewDetails>
       </ReviewContent>

--- a/packages/@divvi/mobile/src/send/SendConfirmation.tsx
+++ b/packages/@divvi/mobile/src/send/SendConfirmation.tsx
@@ -11,6 +11,7 @@ import type { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes } from 'src/components/Button'
 import InfoBottomSheet, { InfoBottomSheetContentBlock } from 'src/components/InfoBottomSheet'
 import {
+  buildAmounts,
   ReviewContent,
   ReviewDetails,
   ReviewDetailsItem,
@@ -219,14 +220,14 @@ export default function SendConfirmation({ route: { params } }: Props) {
             isLoading={prepareTransactionLoading}
             localCurrencySymbol={localCurrencySymbol}
             onInfoPress={() => totalBottomSheetRef.current?.snapToIndex(0)}
-            amounts={[
+            amounts={buildAmounts([
               { tokenInfo, tokenAmount, localAmount },
               {
                 tokenInfo: feeTokenInfo,
                 tokenAmount: tokenEstimatedFeeAmount,
                 localAmount: localEstimatedFeeAmount,
               },
-            ]}
+            ])}
           />
         </ReviewDetails>
       </ReviewContent>
@@ -300,14 +301,14 @@ export default function SendConfirmation({ route: { params } }: Props) {
             type="total-token-amount"
             label={t('reviewTransaction.totalPlusFees')}
             localCurrencySymbol={localCurrencySymbol}
-            amounts={[
+            amounts={buildAmounts([
               { tokenInfo, tokenAmount, localAmount },
               {
                 tokenInfo: feeTokenInfo,
                 tokenAmount: tokenEstimatedFeeAmount,
                 localAmount: localEstimatedFeeAmount,
               },
-            ]}
+            ])}
           />
         </InfoBottomSheetContentBlock>
       </InfoBottomSheet>


### PR DESCRIPTION
### Description
As per the title. More than half of the line changes are tests.
- added network name details item
- added network fee details item with caption for gas subsidized
- added "Total Less Fees" details item with proper calculations dependant on the mode:
  - `withdraw`: `withdraw + rewards - networkFee`
  - `exit`: `withdraw + rewards - networkFee`
  - `claim-rewards`: `rewards - networkFee`


### Test plan
- Adjusted tests for each mode to test the new updated structure
- Added extra test for subsidized gas check (copy-pasted from `EarnConfirmationScreen.test.tsx`)

| Exit | Reward Claim | Partial Withdrawal |
|-|-|-|
| <img src="https://github.com/user-attachments/assets/f1127e5a-ee26-4a36-ba04-0d3bad8010b9" width="250px" /> | <img src="https://github.com/user-attachments/assets/ee7a82ac-f56c-419f-a645-126cb8d9be9c" width="250px" /> | <img src="https://github.com/user-attachments/assets/d1406712-ff1d-46c9-ae6e-a9a108b3fb99" width="250px" /> |

### Related issues

- Relates to [ENG-223](https://linear.app/valora/issue/ENG-223/%5Bwallet%5D-add-new-reviewtransaction-component-to-earnconfirmationscreen)

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
