### PR TITLE
feat: add bottom sheets to `EarnWithdrawConfirmationScreen`

### DIFF
--- a/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
+++ b/packages/@divvi/mobile/src/components/ReviewTransaction.tsx
@@ -338,13 +338,8 @@ export function ReviewDetailsItemTotalValue({
 }: ReviewDetailsItemTotalValueProps) {
   const { t } = useTranslation()
 
-  // filter out "broken" amounts with no token info or token amount
-  const filteredAmounts = amounts.filter(
-    (amount) => !!amount && !!amount.tokenInfo && !!amount.tokenAmount
-  ) as Amount[]
-
-  // if all the amounts are "broken" (which should never happen) then don't return anything
-  if (filteredAmounts.length === 0) {
+  // if there are no amounts then don't return anything
+  if (amounts.length === 0) {
     return null
   }
 
@@ -353,19 +348,19 @@ export function ReviewDetailsItemTotalValue({
    * tokens with variable availability of fiat prices. Based on that, we need to detect the kind of
    * variation and format it accordingly.
    */
-  const amountsGroupedByTokenId = groupBy(filteredAmounts, (amount) => amount.tokenInfo.tokenId)
+  const amountsGroupedByTokenId = groupBy(amounts, (amount) => amount.tokenInfo.tokenId)
   const tokenIds = Object.keys(amountsGroupedByTokenId)
   const sameToken = tokenIds.length === 1
-  const allTokensHaveLocalPrice = filteredAmounts.every((amount) => !!amount.localAmount)
+  const allTokensHaveLocalPrice = amounts.every((amount) => !!amount.localAmount)
 
   /**
    * If all the amounts are of the same token and we have a fiat price for it – then format the value
    * to the format like "1.00 USDC ($1.00)".
    */
   if (sameToken && allTokensHaveLocalPrice) {
-    const tokenInfo = filteredAmounts[0].tokenInfo
-    const tokenAmount = sumAmounts(filteredAmounts, 'tokenAmount')
-    const localAmount = sumAmounts(filteredAmounts, 'localAmount')
+    const tokenInfo = amounts[0].tokenInfo
+    const tokenAmount = sumAmounts(amounts, 'tokenAmount')
+    const localAmount = sumAmounts(amounts, 'localAmount')
     return (
       <ReviewDetailsItemTokenValue
         approx={approx}
@@ -384,8 +379,8 @@ export function ReviewDetailsItemTotalValue({
    * then format the value to only show the sum of all token amounts like "1.00 USDC".
    */
   if (sameToken && !allTokensHaveLocalPrice) {
-    const tokenSymbol = filteredAmounts[0].tokenInfo.symbol
-    const tokenAmount = sumAmounts(filteredAmounts, 'tokenAmount')
+    const tokenSymbol = amounts[0].tokenInfo.symbol
+    const tokenAmount = sumAmounts(amounts, 'tokenAmount')
     const sign = tokenAmount.isNegative() ? '- ' : ''
     const displayTokenAmount = `${sign}${formatValueToDisplay(tokenAmount.abs())}`
     return approx
@@ -398,7 +393,7 @@ export function ReviewDetailsItemTotalValue({
    * to only show the sum of all fiat amounts like "$1.00"
    */
   if (!sameToken && allTokensHaveLocalPrice) {
-    const localAmount = sumAmounts(filteredAmounts, 'localAmount')
+    const localAmount = sumAmounts(amounts, 'localAmount')
     const sign = localAmount.isNegative() ? '- ' : ''
     const displayLocalAmount = formatValueToDisplay(localAmount.abs())
     const symbol = `${sign}${localCurrencySymbol}`

--- a/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.test.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.test.tsx
@@ -179,10 +179,36 @@ describe('EarnWithdrawConfirmationScreen', () => {
       expect(queryByTestId('EarnWithdrawConfirmation/Details/Total/Loader')).toBeFalsy()
     })
 
+    expect(getByTestId('EarnWithdrawConfirmation/Details/NetworkFee/InfoIcon')).toBeTruthy()
+    expect(getByTestId('EarnWithdrawConfirmation/Details/Total/InfoIcon')).toBeTruthy()
     expect(getByTestId('EarnWithdrawConfirmation/Details/NetworkFee/Value')).toHaveTextContent(
       'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
     )
     expect(getByTestId('EarnWithdrawConfirmation/Details/Total/Value')).toHaveTextContent(
+      'localAmountApprox, {"localAmount":"15.66","localCurrencySymbol":"₱"}'
+    )
+
+    // fees info bottom sheet
+    expect(getByTestId('FeeInfoBottomSheet')).toBeTruthy()
+    expect(getByTestId('FeeInfoBottomSheet/FooterDisclaimer')).toHaveTextContent(
+      'feeInfoBottomSheet.feesInfo, {"context":"sameChain"}'
+    )
+
+    // total plus fees info bottom sheet
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Label')).toHaveTextContent(
+      'earnFlow.withdrawConfirmation.withdrawing'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Value')).toHaveTextContent(
+      'tokenAndLocalAmount, {"tokenAmount":"11.83","localAmount":"15.73","tokenSymbol":"USDC","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Fees/Label')).toHaveTextContent('fees')
+    expect(getByTestId('TotalInfoBottomSheet/Fees/Value')).toHaveTextContent(
+      'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Total/Label')).toHaveTextContent(
+      'reviewTransaction.totalLessFees'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Total/Value')).toHaveTextContent(
       'localAmountApprox, {"localAmount":"15.66","localCurrencySymbol":"₱"}'
     )
 
@@ -267,10 +293,36 @@ describe('EarnWithdrawConfirmationScreen', () => {
       expect(queryByTestId('EarnWithdrawConfirmation/Details/Total/Loader')).toBeFalsy()
     })
 
+    expect(getByTestId('EarnWithdrawConfirmation/Details/NetworkFee/InfoIcon')).toBeTruthy()
+    expect(getByTestId('EarnWithdrawConfirmation/Details/Total/InfoIcon')).toBeTruthy()
     expect(getByTestId('EarnWithdrawConfirmation/Details/NetworkFee/Value')).toHaveTextContent(
       'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
     )
     expect(getByTestId('EarnWithdrawConfirmation/Details/Total/Value')).toHaveTextContent(
+      'localAmountApprox, {"localAmount":"0.064","localCurrencySymbol":"- ₱"}'
+    )
+
+    // fees info bottom sheet
+    expect(getByTestId('FeeInfoBottomSheet')).toBeTruthy()
+    expect(getByTestId('FeeInfoBottomSheet/FooterDisclaimer')).toHaveTextContent(
+      'feeInfoBottomSheet.feesInfo, {"context":"sameChain"}'
+    )
+
+    // total plus fees info bottom sheet
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Label')).toHaveTextContent(
+      'earnFlow.withdrawConfirmation.withdrawing'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Value')).toHaveTextContent(
+      'tokenAndLocalAmount, {"tokenAmount":"11.83","localAmount":"15.73","tokenSymbol":"USDC","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Fees/Label')).toHaveTextContent('fees')
+    expect(getByTestId('TotalInfoBottomSheet/Fees/Value')).toHaveTextContent(
+      'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Total/Label')).toHaveTextContent(
+      'reviewTransaction.totalLessFees'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Total/Value')).toHaveTextContent(
       'localAmountApprox, {"localAmount":"0.064","localCurrencySymbol":"- ₱"}'
     )
 
@@ -372,10 +424,36 @@ describe('EarnWithdrawConfirmationScreen', () => {
       expect(queryByTestId('EarnWithdrawConfirmation/Details/Total/Loader')).toBeFalsy()
     })
 
+    expect(getByTestId('EarnWithdrawConfirmation/Details/NetworkFee/InfoIcon')).toBeTruthy()
+    expect(getByTestId('EarnWithdrawConfirmation/Details/Total/InfoIcon')).toBeTruthy()
     expect(getByTestId('EarnWithdrawConfirmation/Details/NetworkFee/Value')).toHaveTextContent(
       'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
     )
     expect(getByTestId('EarnWithdrawConfirmation/Details/Total/Value')).toHaveTextContent(
+      'localAmountApprox, {"localAmount":"7.80","localCurrencySymbol":"₱"}'
+    )
+
+    // fees info bottom sheet
+    expect(getByTestId('FeeInfoBottomSheet')).toBeTruthy()
+    expect(getByTestId('FeeInfoBottomSheet/FooterDisclaimer')).toHaveTextContent(
+      'feeInfoBottomSheet.feesInfo, {"context":"sameChain"}'
+    )
+
+    // total plus fees info bottom sheet
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Label')).toHaveTextContent(
+      'earnFlow.withdrawConfirmation.withdrawing'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Value')).toHaveTextContent(
+      'tokenAndLocalAmount, {"tokenAmount":"5.91","localAmount":"7.86","tokenSymbol":"USDC","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Fees/Label')).toHaveTextContent('fees')
+    expect(getByTestId('TotalInfoBottomSheet/Fees/Value')).toHaveTextContent(
+      'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Total/Label')).toHaveTextContent(
+      'reviewTransaction.totalLessFees'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Total/Value')).toHaveTextContent(
       'localAmountApprox, {"localAmount":"7.80","localCurrencySymbol":"₱"}'
     )
 
@@ -419,6 +497,103 @@ describe('EarnWithdrawConfirmationScreen', () => {
     expect(getByTestId('EarnWithdrawConfirmation/Withdraw')).toBeTruthy()
     expect(queryByTestId('EarnWithdrawConfirmation/RewardClaim-0')).toBeFalsy()
     expect(getByTestId('EarnWithdrawConfirmation/Pool')).toBeTruthy()
+  })
+
+  it('properly sums up withdrawal amount and multiple claimed rewards of different tokens and shows proper total amounts breakdown', async () => {
+    const store = createMockStore({
+      tokens: mockStoreTokens,
+      positions: {
+        positions: [
+          ...mockPositions,
+          mockRewardsPositions[1],
+          {
+            ...mockRewardsPositions[0],
+            positionId:
+              'arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216:supply-incentives',
+          },
+        ],
+      },
+    })
+    const pool = {
+      ...mockEarnPositions[0],
+      balance: '10.75',
+      dataProps: { ...mockEarnPositions[0].dataProps, withdrawalIncludesClaim: true },
+    }
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnWithdrawConfirmationScreen}
+          params={{ mode: 'withdraw', pool, inputTokenAmount: '5' }}
+        />
+      </Provider>
+    )
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnWithdrawConfirmation/Details/NetworkFee/Loader')).toBeFalsy()
+      expect(queryByTestId('EarnWithdrawConfirmation/Details/Total/Loader')).toBeFalsy()
+    })
+
+    // withdraw amount in USDC
+    expect(getByTestId('EarnWithdrawConfirmation/Withdraw/PrimaryValue')).toHaveTextContent(
+      'tokenAmount, {"tokenAmount":"5.00","tokenSymbol":"USDC"}'
+    )
+    expect(getByTestId('EarnWithdrawConfirmation/Withdraw/SecondaryValue')).toHaveTextContent(
+      'localAmount, {"localAmount":"6.65","localCurrencySymbol":"₱"}'
+    )
+
+    // Claimed Reward in ARB
+    expect(getByTestId(`EarnWithdrawConfirmation/RewardClaim-0/PrimaryValue`)).toHaveTextContent(
+      'tokenAmount, {"tokenAmount":"0.01","tokenSymbol":"ARB"}'
+    )
+    expect(getByTestId(`EarnWithdrawConfirmation/RewardClaim-0/SecondaryValue`)).toHaveTextContent(
+      'localAmount, {"localAmount":"0.016","localCurrencySymbol":"₱"}'
+    )
+
+    // Claimed Reward in USDC
+    expect(getByTestId(`EarnWithdrawConfirmation/RewardClaim-1/PrimaryValue`)).toHaveTextContent(
+      'tokenAmount, {"tokenAmount":"10.75","tokenSymbol":"USDC"}'
+    )
+    expect(getByTestId(`EarnWithdrawConfirmation/RewardClaim-1/SecondaryValue`)).toHaveTextContent(
+      'localAmount, {"localAmount":"14.30","localCurrencySymbol":"₱"}'
+    )
+
+    // Network Fee
+    expect(getByTestId('EarnWithdrawConfirmation/Details/NetworkFee/Value')).toHaveTextContent(
+      'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
+    )
+
+    // Total
+    expect(getByTestId('EarnWithdrawConfirmation/Details/Total/Value')).toHaveTextContent(
+      'localAmountApprox, {"localAmount":"20.88","localCurrencySymbol":"₱"}'
+    )
+
+    // Total bottom sheet withdrawing details
+
+    // First label is withdrawing
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Label')).toHaveTextContent(
+      'earnFlow.withdrawConfirmation.withdrawing'
+    )
+    // Withdraw amount in USDC + Claimed Reward in USDC
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-0/Value')).toHaveTextContent(
+      'tokenAndLocalAmount, {"tokenAmount":"15.75","localAmount":"20.95","tokenSymbol":"USDC","localCurrencySymbol":"₱"}'
+    )
+
+    // Second label is empty
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-1/Label')).toBeEmptyElement()
+    // Claimed Reward in ARB
+    expect(getByTestId('TotalInfoBottomSheet/Withdrawing-1/Value')).toHaveTextContent(
+      'tokenAndLocalAmount, {"tokenAmount":"0.01","localAmount":"0.016","tokenSymbol":"ARB","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Fees/Value')).toHaveTextContent(
+      'tokenAndLocalAmountApprox, {"tokenAmount":"0.06","localAmount":"0.08","tokenSymbol":"ETH","localCurrencySymbol":"₱"}'
+    )
+    expect(getByTestId('TotalInfoBottomSheet/Total/Label')).toHaveTextContent(
+      'reviewTransaction.totalLessFees'
+    )
+    // Total is the same as in details
+    expect(getByTestId('TotalInfoBottomSheet/Total/Value')).toHaveTextContent(
+      'localAmountApprox, {"localAmount":"20.88","localCurrencySymbol":"₱"}'
+    )
   })
 
   describe.each([

--- a/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
@@ -47,14 +47,14 @@ const TAG = 'earn/EarnWithdrawConfirmationScreen'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.EarnWithdrawConfirmationScreen>
 
-type FilteredAmount = {
+type Amount = {
   tokenInfo: TokenBalance
   tokenAmount: BigNumber
   localAmount: BigNumber | null
 }
 
-function getTotalWithdrawAmountsPerToken<Amount>(
-  rewardTokens: FilteredAmount[],
+function getTotalWithdrawAmountsPerToken(
+  rewardTokens: Amount[],
   withdraw: ReturnType<typeof useWithdrawAmountInDepositToken>
 ) {
   if (!withdraw.depositToken) {
@@ -71,13 +71,13 @@ function getTotalWithdrawAmountsPerToken<Amount>(
     },
   ]
   const groupedTokens = groupBy(allTokens, (token) => token.tokenInfo.tokenId)
-  const summedTokens: Record<string, FilteredAmount> = {}
+  const summedTokens: Record<string, Amount> = {}
 
   for (const [tokenId, amounts] of Object.entries(groupedTokens)) {
     summedTokens[tokenId] = {
       tokenInfo: amounts[0].tokenInfo,
       tokenAmount: amounts.reduce((acc, token) => acc.plus(token.tokenAmount), new BigNumber(0)),
-      localAmount: amounts.reduce<FilteredAmount['localAmount']>(
+      localAmount: amounts.reduce<Amount['localAmount']>(
         (acc, token) => (acc && token.localAmount ? acc.plus(token.localAmount) : null),
         new BigNumber(0)
       ),
@@ -110,7 +110,7 @@ function useRewards(params: Props['route']['params']) {
       })
       return { tokenAmount, tokenInfo, localAmount, balance: token.balance }
     })
-    .filter((rewardToken) => !!rewardToken.tokenInfo) as Array<FilteredAmount & { balance: string }>
+    .filter((rewardToken) => !!rewardToken.tokenInfo) as Array<Amount & { balance: string }>
 
   return { tokens, tokensInfo, positions }
 }

--- a/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
@@ -1,10 +1,15 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
-import React, { useMemo } from 'react'
+import { groupBy } from 'lodash'
+import React, { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { View } from 'react-native'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
 import { openUrl } from 'src/app/actions'
+import type { BottomSheetModalRefType } from 'src/components/BottomSheet'
+import FeeInfoBottomSheet from 'src/components/FeeInfoBottomSheet'
+import InfoBottomSheet, { InfoBottomSheetContentBlock } from 'src/components/InfoBottomSheet'
 import {
   buildAmounts,
   ReviewContent,
@@ -32,6 +37,7 @@ import { NETWORK_NAMES } from 'src/shared/conts'
 import themeColors from 'src/styles/colors'
 import { useTokenInfo, useTokensInfo, useTokenToLocalAmount } from 'src/tokens/hooks'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
+import type { TokenBalance } from 'src/tokens/slice'
 import { convertTokenToLocalAmount } from 'src/tokens/utils'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
@@ -41,6 +47,49 @@ const TAG = 'earn/EarnWithdrawConfirmationScreen'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.EarnWithdrawConfirmationScreen>
 
+function getTotalWithdrawAmountsPerToken<
+  T extends {
+    tokenInfo: TokenBalance | undefined
+    tokenAmount: BigNumber
+    localAmount: BigNumber | null
+  },
+>(rewardTokens: T[], withdraw: ReturnType<typeof useWithdrawAmountInDepositToken>) {
+  if (!withdraw.depositToken) {
+    Logger.error(TAG, 'depositToken is not available')
+    return []
+  }
+
+  const allTokens = [
+    ...rewardTokens,
+    {
+      tokenInfo: withdraw.depositToken,
+      tokenAmount: withdraw.tokenAmount,
+      localAmount: withdraw.localAmount,
+    },
+  ]
+  const groupedTokens = groupBy(allTokens, (token) => token.tokenInfo!.tokenId)
+  const summedTokens: Record<string, T> = {}
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const tokenId in groupedTokens) {
+    const tokens = groupedTokens[tokenId]
+    summedTokens[tokenId] = {
+      tokenInfo: tokens[0].tokenInfo,
+      tokenAmount: tokens.reduce((acc, token) => acc.plus(token.tokenAmount), new BigNumber(0)),
+      localAmount: tokens.reduce<T['localAmount']>(
+        (acc, token) => (acc && token.localAmount ? acc.plus(token.localAmount) : null),
+        new BigNumber(0)
+      ),
+    } as T
+  }
+
+  const sortedTokens = Object.values(summedTokens).sort((token) =>
+    token.tokenInfo!.tokenId === withdraw.depositToken!.tokenId ? -1 : 0
+  )
+
+  return sortedTokens
+}
+
 function useRewards(params: Props['route']['params']) {
   const { rewardsPositionIds } = params.pool.dataProps
   const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
@@ -48,22 +97,19 @@ function useRewards(params: Props['route']['params']) {
     rewardsPositionIds?.includes(position.positionId)
   )
   const tokensInfo = useTokensInfo(positions.map((position) => position.tokens[0]?.tokenId))
-  const tokens = useMemo(
-    () =>
-      positions
-        .flatMap((position) => position.tokens)
-        .map((token) => {
-          const tokenAmount = new BigNumber(token.balance)
-          const tokenInfo = tokensInfo.find((info) => info?.tokenId === token.tokenId)
-          const localAmount = convertTokenToLocalAmount({
-            tokenAmount,
-            tokenInfo,
-            usdToLocalRate,
-          })
-          return { tokenAmount, tokenInfo, localAmount, balance: token.balance }
-        }),
-    [positions, tokensInfo, usdToLocalRate]
-  )
+  const tokens = positions
+    .flatMap((position) => position.tokens)
+    .map((token) => {
+      const tokenAmount = new BigNumber(token.balance)
+      const tokenInfo = tokensInfo.find((info) => info?.tokenId === token.tokenId)
+      const localAmount = convertTokenToLocalAmount({
+        tokenAmount,
+        tokenInfo,
+        usdToLocalRate,
+      })
+      return { tokenAmount, tokenInfo, localAmount, balance: token.balance }
+    })
+    .filter((rewardToken) => !!rewardToken.tokenInfo)
 
   return { tokens, tokensInfo, positions }
 }
@@ -87,9 +133,12 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const providerUrl = params.pool.dataProps.manageUrl ?? params.pool.dataProps.termsUrl
-  const localCurrencySymbol = useSelector(getLocalCurrencySymbol) ?? LocalCurrencySymbol.USD
+  const feeBottomSheetRef = useRef<BottomSheetModalRefType>(null)
+  const totalBottomSheetRef = useRef<BottomSheetModalRefType>(null)
   const rewards = useRewards(params)
   const withdraw = useWithdrawAmountInDepositToken(params)
+  const totalWithdrawAmountsPerToken = getTotalWithdrawAmountsPerToken(rewards.tokens, withdraw)
+  const localCurrencySymbol = useSelector(getLocalCurrencySymbol) ?? LocalCurrencySymbol.USD
   const hooksApiUrl = useSelector(hooksApiUrlSelector)
   const walletAddress = (useSelector(walletAddressSelector) || '') as Address
   const feeCurrencies = useSelector((state) =>
@@ -109,7 +158,6 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
     rewardsPositions: rewards.positions,
     useMax: params.mode !== 'withdraw' || params.useMax,
   })
-
   const networkFee = useNetworkFee(preparedTransaction.result)
 
   function onPressProvider() {
@@ -171,27 +219,25 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
           {(params.mode === 'claim-rewards' ||
             params.mode === 'exit' ||
             params.pool.dataProps.withdrawalIncludesClaim) &&
-            rewards.tokens
-              .filter((rewardToken) => !!rewardToken.tokenInfo)
-              .map((rewardToken, idx) => (
-                <ReviewSummaryItem
-                  key={idx}
-                  testID={`EarnWithdrawConfirmation/RewardClaim-${idx}`}
-                  label={t('earnFlow.withdrawConfirmation.rewardClaiming')}
-                  icon={<TokenIcon token={rewardToken.tokenInfo!} />}
-                  primaryValue={t('tokenAmount', {
-                    tokenAmount: formatValueToDisplay(rewardToken.tokenAmount),
-                    tokenSymbol: rewardToken.tokenInfo?.symbol,
-                  })}
-                  secondaryValue={t('localAmount', {
-                    context: rewardToken.localAmount ? undefined : 'noFiatPrice',
-                    localAmount: rewardToken.localAmount
-                      ? formatValueToDisplay(rewardToken.localAmount)
-                      : '',
-                    localCurrencySymbol,
-                  })}
-                />
-              ))}
+            rewards.tokens.map((rewardToken, idx) => (
+              <ReviewSummaryItem
+                key={idx}
+                testID={`EarnWithdrawConfirmation/RewardClaim-${idx}`}
+                label={t('earnFlow.withdrawConfirmation.rewardClaiming')}
+                icon={<TokenIcon token={rewardToken.tokenInfo!} />}
+                primaryValue={t('tokenAmount', {
+                  tokenAmount: formatValueToDisplay(rewardToken.tokenAmount),
+                  tokenSymbol: rewardToken.tokenInfo?.symbol,
+                })}
+                secondaryValue={t('localAmount', {
+                  context: rewardToken.localAmount ? undefined : 'noFiatPrice',
+                  localAmount: rewardToken.localAmount
+                    ? formatValueToDisplay(rewardToken.localAmount)
+                    : '',
+                  localCurrencySymbol,
+                })}
+              />
+            ))}
 
           <ReviewSummaryItem
             testID="EarnWithdrawConfirmation/Pool"
@@ -230,6 +276,7 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
             localAmount={networkFee?.localAmount}
             tokenInfo={networkFee?.token}
             localCurrencySymbol={localCurrencySymbol}
+            onInfoPress={() => feeBottomSheetRef.current?.snapToIndex(0)}
           />
 
           <ReviewDetailsItem
@@ -239,6 +286,7 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
             label={t('reviewTransaction.totalLessFees')}
             localCurrencySymbol={localCurrencySymbol}
             isLoading={preparedTransaction.loading}
+            onInfoPress={() => totalBottomSheetRef.current?.snapToIndex(0)}
             amounts={buildAmounts([
               params.mode !== 'claim-rewards' && {
                 tokenInfo: withdraw.depositToken,
@@ -256,6 +304,70 @@ export default function EarnWithdrawConfirmationScreen({ route: { params } }: Pr
           />
         </ReviewDetails>
       </ReviewContent>
+
+      <FeeInfoBottomSheet forwardedRef={feeBottomSheetRef} networkFee={networkFee} />
+
+      <InfoBottomSheet
+        forwardedRef={totalBottomSheetRef}
+        title={t('reviewTransaction.totalLessFees')}
+        testID="TotalInfoBottomSheet"
+      >
+        <InfoBottomSheetContentBlock>
+          <View>
+            {totalWithdrawAmountsPerToken.map((token, idx) => (
+              <ReviewDetailsItem
+                key={token.tokenInfo!.tokenId}
+                fontSize="small"
+                type="token-amount"
+                testID={`TotalInfoBottomSheet/Withdrawing-${idx}`}
+                label={idx === 0 ? t('earnFlow.withdrawConfirmation.withdrawing') : ''}
+                localCurrencySymbol={localCurrencySymbol}
+                {...token}
+              />
+            ))}
+          </View>
+
+          {networkFee && (
+            <ReviewDetailsItem
+              approx
+              fontSize="small"
+              type="token-amount"
+              testID="TotalInfoBottomSheet/Fees"
+              label={t('fees')}
+              caption={isGasSubsidized ? t('gasSubsidized') : undefined}
+              captionColor={isGasSubsidized ? themeColors.accent : undefined}
+              strikeThrough={isGasSubsidized}
+              tokenAmount={networkFee.amount}
+              localAmount={networkFee.localAmount}
+              tokenInfo={networkFee.token}
+              localCurrencySymbol={localCurrencySymbol}
+            />
+          )}
+
+          <ReviewDetailsItem
+            approx
+            fontSize="small"
+            type="total-token-amount"
+            testID="TotalInfoBottomSheet/Total"
+            label={t('reviewTransaction.totalLessFees')}
+            localCurrencySymbol={localCurrencySymbol}
+            amounts={buildAmounts([
+              params.mode !== 'claim-rewards' && {
+                tokenInfo: withdraw.depositToken,
+                tokenAmount: withdraw.tokenAmount,
+                localAmount: withdraw.localAmount,
+              },
+              {
+                isDeductible: true,
+                tokenInfo: networkFee?.token,
+                tokenAmount: networkFee?.amount,
+                localAmount: networkFee?.localAmount,
+              },
+              ...rewards.tokens,
+            ])}
+          />
+        </InfoBottomSheetContentBlock>
+      </InfoBottomSheet>
     </ReviewTransaction>
   )
 }


### PR DESCRIPTION
### Description
As per the title.
- added info sheet for fees
- added info sheet for "Total Less fees"
- added function that sums up withdrawal amount and claimed rewards on a per-token basis and sorts it so the withdrawal token is the first in the breakdown in the `Total Less Fees` bottom info sheet

Please ignore that it says **_Total Plus Fees_** in the info sheet title on the screenshots – I've already pushed a fix in [this commit](https://github.com/divvi-xyz/divvi-mobile/pull/184/commits/5ba44ae6f49b1d57998083ece4c39fa27b974334)

### Test plan
- adjusted existing structural tests to include new components
- added test to ensure correct calculations and when there is multiple rewards with different tokens


#### Withdrawal with no rewards
|<img src="https://github.com/user-attachments/assets/3d5acce5-29ed-4277-9b00-4b6371dd7bf4" width="250px" />|<img src="https://github.com/user-attachments/assets/c1db9e6b-ae96-42a7-b50d-28e39d4d017d" width="250px" />|<img src="https://github.com/user-attachments/assets/f04cba2f-2d6f-4c5b-91d3-61f909c0e05a" width="250px" />|
|-|-|-|

#### Withdrawal with single reward of different token
##### _(mocked data)_
|<img src="https://github.com/user-attachments/assets/4cd43bbb-01de-4a27-9198-e9f24f206f73" width="350px" />|<img src="https://github.com/user-attachments/assets/6a7d4c5b-65f2-4bd9-8fc5-eca7c0e3a205" width="350px" />|
|-|-|

#### Withdrawal with multiple rewards where withdrawal amount and reward of the same token are summed 
##### _(mocked data)_
|<img src="https://github.com/user-attachments/assets/1f56ad5b-ef62-4787-9fe4-283e43fbfd2a" width="350px" />|<img src="https://github.com/user-attachments/assets/26ae5b95-d11b-4119-bbcb-daa411fcfea4" width="350px" />|
|-|-|

### Related issues

- Relates to [ENG-223](https://linear.app/valora/issue/ENG-223/%5Bwallet%5D-add-new-reviewtransaction-component-to-earnconfirmationscreen)

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
