### PR TITLE
chore: update divvi bot token for crowdin CI

### DIFF
--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -6,6 +6,9 @@ on:
   # https://crontab.guru/#0_2_*_*_*
   schedule:
     - cron: '0 2 * * *'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   automerge-crowdin-pr:

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -25,7 +25,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2.2.2
         with:
           secrets: |-
-            DIVVI_BOT_TOKEN:projects/1027349420744/secrets/DIVVI_BOT_TOKEN
+            DIVVI_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
       - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -25,7 +25,7 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2.2.2
         with:
           secrets: |-
-            DIVVI_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
+            DIVVI_BOT_TOKEN:projects/1027349420744/secrets/DIVVI_BOT_TOKEN
       - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -22,11 +22,11 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2.2.2
         with:
           secrets: |-
-            VALORA_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
+            DIVVI_BOT_TOKEN:projects/1027349420744/secrets/DIVVI_BOT_TOKEN
       - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.google-secrets.outputs.VALORA_BOT_TOKEN }}
+          github-token: ${{ steps.google-secrets.outputs.DIVVI_BOT_TOKEN }}
           script: |
             const script = require('.github/scripts/automergeCrowdinPr.js')
             await script({github, context, core})

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -6,9 +6,6 @@ on:
   # https://crontab.guru/#0_2_*_*_*
   schedule:
     - cron: '0 2 * * *'
-  pull_request:
-    branches:
-      - main
 
 jobs:
   automerge-crowdin-pr:

--- a/.github/workflows/automerge-translation.yml
+++ b/.github/workflows/automerge-translation.yml
@@ -22,11 +22,11 @@ jobs:
         uses: google-github-actions/get-secretmanager-secrets@v2.2.2
         with:
           secrets: |-
-            VALORA_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
+            DIVVI_BOT_TOKEN:projects/1027349420744/secrets/DIVVI_BOT_TOKEN
       - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.google-secrets.outputs.VALORA_BOT_TOKEN }}
+          github-token: ${{ steps.google-secrets.outputs.DIVVI_BOT_TOKEN }}
           script: |
             const script = require('.github/scripts/automergeTranslationPrs.js')
             await script({github, context, core})


### PR DESCRIPTION
### Description

To get the automerge for the crowdin PRs working, I needed to add the divvi-bot user to the divvi-xyz org and generate a new PAT. This has been added to secret manager (the PAT used for the valora wallet CI is still needed for the app version workflow, so I couldn't just replace it)

### Test plan

[Example](https://github.com/divvi-xyz/divvi-mobile/actions/runs/14306613706/job/40092386591?pr=185) of CI auto updating and approving the crowdin branch.

### Related issues

- Fixes ENG-196

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
