### PR TITLE
feat: add footer and notifications to `EarnWithdrawConfirmationScreen`

### DIFF
--- a/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
+++ b/packages/@divvi/mobile/src/earn/EarnWithdrawConfirmationScreen.tsx
@@ -118,7 +118,7 @@ function useRewards(params: Props['route']['params']) {
       })
       return { tokenAmount, tokenInfo, localAmount, balance: token.balance }
     })
-    .filter((token) => !!token.tokenInfo) as Array<Amount & { balance: string }>
+    .filter((token): token is Amount & { balance: string } => !!token.tokenInfo)
 
   return { tokens, tokensInfo, positions, flattenedPositionTokens }
 }


### PR DESCRIPTION
### Description
As per the title.
- added "prepare tx" error and "no gas" warning inline notifications 
- added confirm button

### Test plan
- adjusted structural tests to include new components
- copied tests from `EarnConfirmationScreen.test.tsx` to test notifications and confirm button

| **No Gas warning with CTA and confirm button** <img src="https://github.com/user-attachments/assets/0a51c7fe-01d6-4d6c-9679-d43ec00155c1" width="350px" />| **Prepare Transaction error and confirm button** <img src="https://github.com/user-attachments/assets/092691e7-c835-4888-a77a-d7ce75ceed5e" width="350px" />|
|-|-|


### Related issues
- Relates to [ENG-223](https://linear.app/valora/issue/ENG-223/%5Bwallet%5D-add-new-reviewtransaction-component-to-earnconfirmationscreen)
### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
