### PR TITLE
fix: estimateFeesPerGas without getGasPriceMinimum on Celo

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -104,7 +104,7 @@
     "ts-node": "^11.0.0-beta.1",
     "ts-retry-promise": "^0.6.0",
     "typescript": "^5.6.2",
-    "viem": "^2.21.55"
+    "viem": "^2.24.1"
   },
   "private": true
 }

--- a/packages/@divvi/mobile/package.json
+++ b/packages/@divvi/mobile/package.json
@@ -183,7 +183,7 @@
     "typed-redux-saga": "^1.5.0",
     "uuid": "^10.0.0",
     "victory-native": "^36.9.2",
-    "viem": "^2.21.55",
+    "viem": "^2.24.1",
     "web3-utils": "^4.3.3"
   },
   "devDependencies": {

--- a/packages/@divvi/mobile/src/viem/estimateFeesPerGas.test.ts
+++ b/packages/@divvi/mobile/src/viem/estimateFeesPerGas.test.ts
@@ -27,7 +27,7 @@ describe(estimateFeesPerGas, () => {
     }
     const fees = await estimateFeesPerGas(client as any)
     expect(fees).toEqual({
-      maxFeePerGas: BigInt(70), // baseFeePerGas * 1.2 (default multiplier in viem)
+      maxFeePerGas: BigInt(70), // baseFeePerGas * 1.2 (default multiplier in viem) + maxPriorityFeePerGas
       maxPriorityFeePerGas: BigInt(10),
       baseFeePerGas: BigInt(50),
     })

--- a/packages/@divvi/mobile/src/viem/estimateFeesPerGas.test.ts
+++ b/packages/@divvi/mobile/src/viem/estimateFeesPerGas.test.ts
@@ -1,27 +1,23 @@
 import { estimateFeesPerGas } from 'src/viem/estimateFeesPerGas'
 import networkConfig from 'src/web3/networkConfig'
 import { Block } from 'viem'
-import {
-  estimateFeesPerGas as defaultEstimateFeesPerGas,
-  getBlock,
-  readContract,
-} from 'viem/actions'
+import { getBlock } from 'viem/actions'
+import { mainnet } from 'viem/chains'
 
 jest.mock('viem/actions', () => ({
+  ...jest.requireActual('viem/actions'),
   getBlock: jest.fn(),
-  estimateFeesPerGas: jest.fn(),
-  readContract: jest.fn(),
 }))
 
 beforeEach(() => {
   jest.clearAllMocks()
+  jest.mocked(getBlock).mockResolvedValue({ baseFeePerGas: BigInt(50) } as Block)
 })
 
 describe(estimateFeesPerGas, () => {
   it('should return the correct fees per gas on Celo', async () => {
-    jest.mocked(readContract).mockResolvedValue(BigInt(50))
     const client = {
-      chain: { id: networkConfig.viemChain.celo.id },
+      chain: networkConfig.viemChain.celo,
       request: jest.fn(async ({ method, params }) => {
         expect(params).toBeUndefined()
         if (method === 'eth_gasPrice') return '0x64' // 100 in hex
@@ -31,26 +27,19 @@ describe(estimateFeesPerGas, () => {
     }
     const fees = await estimateFeesPerGas(client as any)
     expect(fees).toEqual({
-      maxFeePerGas: BigInt(110),
+      maxFeePerGas: BigInt(70), // baseFeePerGas * 1.2 (default multiplier in viem)
       maxPriorityFeePerGas: BigInt(10),
       baseFeePerGas: BigInt(50),
     })
-    expect(defaultEstimateFeesPerGas).not.toHaveBeenCalled()
-    expect(getBlock).not.toHaveBeenCalled()
-    expect(readContract).toHaveBeenCalledWith(
-      client,
-      expect.objectContaining({
-        functionName: 'getGasPriceMinimum',
-        args: [networkConfig.celoTokenAddress],
-      })
-    )
   })
 
   it('should return the correct fees per gas on Celo when fee currency is specified', async () => {
-    jest.mocked(readContract).mockResolvedValue(BigInt(50))
     const client = {
-      chain: { id: networkConfig.viemChain.celo.id },
+      chain: networkConfig.viemChain.celo,
       request: jest.fn(async ({ method, params }) => {
+        // Celo's estimateFeePerGas calls it to check whether we're post L2
+        // See https://github.com/wevm/viem/blob/8c425c3be08f6cedc3d8fcca9f8cfe1fe493a4a3/src/celo/fees.ts#L101-L105
+        if (method === 'eth_getCode') return '0x1'
         expect(params).toEqual(['0x123'])
         if (method === 'eth_gasPrice') return '0x64' // 100 in hex
         if (method === 'eth_maxPriorityFeePerGas') return '0xa' // 10 in hex
@@ -58,74 +47,83 @@ describe(estimateFeesPerGas, () => {
       }),
     }
     const fees = await estimateFeesPerGas(client as any, '0x123')
+    // eth_gasPrice for cel2 returns baseFeePerGas + maxPriorityFeePerGas
     expect(fees).toEqual({
-      maxFeePerGas: BigInt(110),
+      maxFeePerGas: BigInt(118), // (eth_gasPrice - eth_maxPriorityFeePerGas) * 1.2 + eth_maxPriorityFeePerGas
       maxPriorityFeePerGas: BigInt(10),
-      baseFeePerGas: BigInt(50),
+      baseFeePerGas: BigInt(90), // eth_gasPrice - eth_maxPriorityFeePerGas
     })
-    expect(defaultEstimateFeesPerGas).not.toHaveBeenCalled()
-    expect(getBlock).not.toHaveBeenCalled()
-    expect(readContract).toHaveBeenCalledWith(
-      client,
-      expect.objectContaining({
-        functionName: 'getGasPriceMinimum',
-        args: ['0x123'],
-      })
+  })
+
+  it('should throw if fee currency is specified but not able to capture baseFeePerGas', async () => {
+    const client = {
+      chain: {
+        ...networkConfig.viemChain.celo,
+        fees: {
+          // This custom estimateFeesPerGas doesn't call multiply, so it won't capture the baseFeePerGas
+          estimateFeesPerGas: jest.fn(async () => ({
+            maxFeePerGas: BigInt(130),
+            maxPriorityFeePerGas: BigInt(10),
+          })),
+        },
+      },
+      request: jest.fn(async ({ method, params }) => {
+        throw new Error(`Unknown method ${method}`)
+      }),
+    }
+    await expect(estimateFeesPerGas(client as any, '0x123')).rejects.toThrow(
+      'Unable to capture baseFeePerGas'
     )
   })
 
   it('should return the default fees per gas on other networks', async () => {
-    jest
-      .mocked(defaultEstimateFeesPerGas)
-      .mockResolvedValue({ maxFeePerGas: BigInt(110), maxPriorityFeePerGas: BigInt(10) })
-    const mockBlock = { baseFeePerGas: BigInt(50) } as Block
-    jest.mocked(getBlock).mockResolvedValue(mockBlock)
     const client = {
-      chain: { id: 1 },
+      chain: mainnet,
+      request: jest.fn(async ({ method, params }) => {
+        expect(params).toBeUndefined()
+        if (method === 'eth_maxPriorityFeePerGas') return '0xa' // 10 in hex
+        throw new Error(`Unknown method ${method}`)
+      }),
     }
     const fees = await estimateFeesPerGas(client as any)
     expect(fees).toEqual({
-      maxFeePerGas: BigInt(110),
+      maxFeePerGas: BigInt(70),
       maxPriorityFeePerGas: BigInt(10),
       baseFeePerGas: BigInt(50),
     })
-    expect(defaultEstimateFeesPerGas).toHaveBeenCalledWith(client, { block: mockBlock })
-    expect(defaultEstimateFeesPerGas).toHaveBeenCalledTimes(1)
     expect(getBlock).toHaveBeenCalledWith(client)
     expect(getBlock).toHaveBeenCalledTimes(1)
-    expect(readContract).not.toHaveBeenCalled()
   })
 
   it('should throw on other networks when fee currency is specified', async () => {
-    jest
-      .mocked(defaultEstimateFeesPerGas)
-      .mockResolvedValue({ maxFeePerGas: BigInt(110), maxPriorityFeePerGas: BigInt(10) })
-    jest.mocked(getBlock).mockResolvedValue({ baseFeePerGas: BigInt(50) } as Block)
     const client = {
-      chain: { id: 1 },
+      chain: mainnet,
+      request: jest.fn(async ({ method, params }) => {
+        expect(params).toBeUndefined()
+        if (method === 'eth_maxPriorityFeePerGas') return '0xa' // 10 in hex
+        throw new Error(`Unknown method ${method}`)
+      }),
     }
-    await expect(estimateFeesPerGas(client as any, '0x123')).rejects.toThrowError(
+    await expect(estimateFeesPerGas(client as any, '0x123')).rejects.toThrow(
       'feeCurrency is only supported on Celo'
     )
-    expect(defaultEstimateFeesPerGas).not.toHaveBeenCalled()
     expect(getBlock).not.toHaveBeenCalled()
-    expect(readContract).not.toHaveBeenCalled()
   })
 
   it('should throw on other networks if baseFeePerGas is missing', async () => {
-    jest
-      .mocked(defaultEstimateFeesPerGas)
-      .mockResolvedValue({ maxFeePerGas: BigInt(110), maxPriorityFeePerGas: BigInt(10) })
     jest.mocked(getBlock).mockResolvedValue({ hash: '0x123', baseFeePerGas: null } as any as Block)
     const client = {
-      chain: { id: 1 },
+      chain: mainnet,
+      request: jest.fn(async ({ method, params }) => {
+        expect(params).toBeUndefined()
+        if (method === 'eth_maxPriorityFeePerGas') return '0xa' // 10 in hex
+        throw new Error(`Unknown method ${method}`)
+      }),
     }
-    await expect(estimateFeesPerGas(client as any)).rejects.toThrowError(
+    await expect(estimateFeesPerGas(client as any)).rejects.toThrow(
       'missing baseFeePerGas on block: 0x123'
     )
-    expect(defaultEstimateFeesPerGas).not.toHaveBeenCalled()
     expect(getBlock).toHaveBeenCalledWith(client)
     expect(getBlock).toHaveBeenCalledTimes(1)
-    expect(readContract).not.toHaveBeenCalled()
   })
 })

--- a/packages/@divvi/mobile/src/viem/estimateFeesPerGas.ts
+++ b/packages/@divvi/mobile/src/viem/estimateFeesPerGas.ts
@@ -1,32 +1,40 @@
 import networkConfig from 'src/web3/networkConfig'
-import { Address, Client, hexToBigInt } from 'viem'
-import {
-  estimateFeesPerGas as defaultEstimateFeesPerGas,
-  getBlock,
-  readContract,
-} from 'viem/actions'
+import { Address, Client } from 'viem'
+import { estimateFeesPerGas as defaultEstimateFeesPerGas, getBlock } from 'viem/actions'
 
 export async function estimateFeesPerGas(
   client: Client,
   feeCurrency?: Address
 ): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint; baseFeePerGas: bigint }> {
-  // Custom path for Celo that can be removed once it's supported in viem
-  // See https://github.com/wagmi-dev/viem/discussions/914
-  if (client.chain?.id === networkConfig.viemChain.celo.id) {
-    // The gasPrice returned on Celo is already roughly 2x baseFeePerGas
-    // See this thread for more context:
-    // https://valora-app.slack.com/archives/CNJ7KTHQU/p1697717100995909?thread_ts=1697647756.662059&cid=CNJ7KTHQU
-    const [gasPrice, maxPriorityFeePerGas, gasPriceMinimum] = await Promise.all([
-      getGasPrice(client, feeCurrency),
-      getMaxPriorityFeePerGas(client, feeCurrency),
-      getCeloGasPriceMinimum(client, feeCurrency),
-    ])
-    const maxFeePerGas = gasPrice + maxPriorityFeePerGas
-
-    return { maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas: gasPriceMinimum }
+  // Wrap chain.fees.estimateFeesPerGas to capture the baseFeePerGas
+  // This way we still rely on Celo's (or other chains') estimateFeesPerGas
+  // with fee currency support and proper multiplier applied, but we can capture the baseFeePerGas
+  // See https://github.com/wevm/viem/blob/8c425c3be08f6cedc3d8fcca9f8cfe1fe493a4a3/src/celo/fees.ts#L21-L46
+  // TODO: contribute this somehow to viem so we don't need this hack
+  let capturedBaseFeePerGas: bigint | undefined = undefined
+  const chainEstimateFeesPerGas = client.chain?.fees?.estimateFeesPerGas
+  if (client.chain?.fees && typeof chainEstimateFeesPerGas === 'function') {
+    client = {
+      ...client,
+      chain: {
+        ...client.chain,
+        fees: {
+          ...client.chain.fees,
+          estimateFeesPerGas: async (params) => {
+            return chainEstimateFeesPerGas({
+              ...params,
+              multiply: (base: bigint) => {
+                capturedBaseFeePerGas = base
+                return params.multiply(base)
+              },
+            })
+          },
+        },
+      },
+    }
   }
 
-  if (feeCurrency) {
+  if (feeCurrency && client.chain?.id !== networkConfig.viemChain.celo.id) {
     throw new Error('feeCurrency is only supported on Celo')
   }
 
@@ -38,59 +46,25 @@ export async function estimateFeesPerGas(
     throw new Error(`missing baseFeePerGas on block: ${block.hash}`)
   }
 
-  return {
-    ...(await defaultEstimateFeesPerGas(client, {
-      // estimateFeesPerGas calls internal_estimateFeesPerGas
-      // which accepts a block as an argument, but it's not exposed publicly
-      // We do this so we don't fetch the latest block twice.
-      // See https://github.com/wevm/viem/blob/7c479d86ad68daf2fd8874cbc6eec08d6456e540/src/actions/public/estimateFeesPerGas.ts#L91
-      // @ts-expect-error
-      block,
-    })),
-    baseFeePerGas: block.baseFeePerGas,
+  const { maxFeePerGas, maxPriorityFeePerGas } = await defaultEstimateFeesPerGas(client, {
+    // estimateFeesPerGas calls internal_estimateFeesPerGas
+    // which accepts a block as an argument, but it's not exposed publicly
+    // We do this so we don't fetch the latest block twice.
+    // See https://github.com/wevm/viem/blob/7c479d86ad68daf2fd8874cbc6eec08d6456e540/src/actions/public/estimateFeesPerGas.ts#L91
+    // @ts-expect-error
+    block,
+    // Celo estimateFeesPerGas needs it to estimate using a feeCurrency
+    request: feeCurrency ? { feeCurrency } : undefined,
+  })
+
+  if (feeCurrency && !capturedBaseFeePerGas) {
+    // This should never happen
+    throw new Error('Unable to capture baseFeePerGas')
   }
-}
 
-// Get gas price with optional fee currency, this is Celo specific
-// See https://docs.celo.org/developer/viem#gas-price
-async function getGasPrice(client: Client, feeCurrency: Address | undefined) {
-  const priceHex = await client.request({
-    method: 'eth_gasPrice',
-    ...((feeCurrency ? { params: [feeCurrency] } : {}) as object),
-  })
-  return hexToBigInt(priceHex)
-}
-
-// Get max priority fee per gas with optional fee currency, this is Celo specific
-async function getMaxPriorityFeePerGas(client: Client, feeCurrency?: Address) {
-  const maxPriorityFeePerGasHex = await client.request({
-    method: 'eth_maxPriorityFeePerGas',
-    ...((feeCurrency ? { params: [feeCurrency] } : {}) as object),
-  })
-  return hexToBigInt(maxPriorityFeePerGasHex)
-}
-
-// Get gas price minimum with optional fee currency, this is Celo specific
-async function getCeloGasPriceMinimum(client: Client, feeCurrency: Address | undefined) {
-  const gasPriceMinimum = await readContract(client, {
-    address: networkConfig.celoGasPriceMinimumAddress,
-    // Extracted the ABI from https://unpkg.com/browse/@celo/abis@10.0.0/dist/GasPriceMinimum.json
-    abi: [
-      {
-        constant: true,
-        inputs: [{ internalType: 'address', name: 'tokenAddress', type: 'address' }],
-        name: 'getGasPriceMinimum',
-        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-        payable: false,
-        stateMutability: 'view',
-        type: 'function',
-      },
-    ] as const,
-    functionName: 'getGasPriceMinimum',
-    // The contract doesn't accept an undefined or empty feeCurrency for the native token
-    // Unlike eth_gasPrice or eth_maxPriorityFeePerGas
-    args: [feeCurrency ?? networkConfig.celoTokenAddress],
-  })
-
-  return gasPriceMinimum
+  return {
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    baseFeePerGas: capturedBaseFeePerGas ?? block.baseFeePerGas,
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,13 +2421,6 @@
   dependencies:
     "@noble/hashes" "1.4.0"
 
-"@noble/curves@1.7.0", "@noble/curves@^1.4.0", "@noble/curves@^1.6.0", "@noble/curves@~1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.7.0.tgz#0512360622439256df892f21d25b388f52505e45"
-  integrity sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==
-  dependencies:
-    "@noble/hashes" "1.6.0"
-
 "@noble/curves@1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.8.0.tgz#fe035a23959e6aeadf695851b51a87465b5ba8f7"
@@ -2435,12 +2428,19 @@
   dependencies:
     "@noble/hashes" "1.7.0"
 
-"@noble/curves@1.8.1":
+"@noble/curves@1.8.1", "@noble/curves@~1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.8.1.tgz#19bc3970e205c99e4bdb1c64a4785706bce497ff"
   integrity sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==
   dependencies:
     "@noble/hashes" "1.7.1"
+
+"@noble/curves@^1.6.0", "@noble/curves@~1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.7.0.tgz#0512360622439256df892f21d25b388f52505e45"
+  integrity sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==
+  dependencies:
+    "@noble/hashes" "1.6.0"
 
 "@noble/hashes@1.3.2":
   version "1.3.2"
@@ -2457,11 +2457,6 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.0.tgz#d4bfb516ad6e7b5111c216a5cc7075f4cf19e6c5"
   integrity sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==
 
-"@noble/hashes@1.6.1", "@noble/hashes@^1.1.2", "@noble/hashes@^1.4.0", "@noble/hashes@^1.5.0", "@noble/hashes@~1.6.0":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.1.tgz#df6e5943edcea504bac61395926d6fd67869a0d5"
-  integrity sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==
-
 "@noble/hashes@1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.0.tgz#5d9e33af2c7d04fee35de1519b80c958b2e35e39"
@@ -2471,6 +2466,11 @@
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
   integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
+
+"@noble/hashes@^1.1.2", "@noble/hashes@^1.5.0", "@noble/hashes@~1.6.0":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.1.tgz#df6e5943edcea504bac61395926d6fd67869a0d5"
+  integrity sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==
 
 "@noble/secp256k1@^1.7.1":
   version "1.7.1"
@@ -3528,7 +3528,7 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.1.tgz#dd0b2a533063ca612c17aa9ad26424a2ff5aa865"
   integrity sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==
 
-"@scure/base@~1.2.4":
+"@scure/base@~1.2.2", "@scure/base@~1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.4.tgz#002eb571a35d69bdb4c214d0995dff76a8dcd2a9"
   integrity sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==
@@ -3542,7 +3542,16 @@
     "@noble/hashes" "~1.4.0"
     "@scure/base" "~1.1.6"
 
-"@scure/bip32@1.6.0", "@scure/bip32@^1.5.0":
+"@scure/bip32@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.6.2.tgz#093caa94961619927659ed0e711a6e4bf35bffd0"
+  integrity sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==
+  dependencies:
+    "@noble/curves" "~1.8.1"
+    "@noble/hashes" "~1.7.1"
+    "@scure/base" "~1.2.2"
+
+"@scure/bip32@^1.5.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.6.0.tgz#6dbc6b4af7c9101b351f41231a879d8da47e0891"
   integrity sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==
@@ -3559,21 +3568,21 @@
     "@noble/hashes" "~1.4.0"
     "@scure/base" "~1.1.6"
 
-"@scure/bip39@1.5.0", "@scure/bip39@^1.4.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.5.0.tgz#c8f9533dbd787641b047984356531d84485f19be"
-  integrity sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==
-  dependencies:
-    "@noble/hashes" "~1.6.0"
-    "@scure/base" "~1.2.1"
-
-"@scure/bip39@^1.5.4":
+"@scure/bip39@1.5.4", "@scure/bip39@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.5.4.tgz#07fd920423aa671be4540d59bdd344cc1461db51"
   integrity sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==
   dependencies:
     "@noble/hashes" "~1.7.1"
     "@scure/base" "~1.2.4"
+
+"@scure/bip39@^1.4.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.5.0.tgz#c8f9533dbd787641b047984356531d84485f19be"
+  integrity sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==
+  dependencies:
+    "@noble/hashes" "~1.6.0"
+    "@scure/base" "~1.2.1"
 
 "@sec-ant/readable-stream@^0.4.1":
   version "0.4.1"
@@ -5833,7 +5842,12 @@ abbrev@^3.0.0:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-3.0.0.tgz#c29a6337e167ac61a84b41b80461b29c5c271a27"
   integrity sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==
 
-abitype@1.0.7, abitype@^1.0.6:
+abitype@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.8.tgz#3554f28b2e9d6e9f35eb59878193eabd1b9f46ba"
+  integrity sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==
+
+abitype@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.7.tgz#876a0005d211e1c9132825d45bcee7b46416b284"
   integrity sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==
@@ -13016,10 +13030,10 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-ox@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ox/-/ox-0.1.2.tgz#0f791be2ccabeaf4928e6d423498fe1c8094e560"
-  integrity sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==
+ox@0.6.9:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.6.9.tgz#da1ee04fa10de30c8d04c15bfb80fe58b1f554bd"
+  integrity sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==
   dependencies:
     "@adraffy/ens-normalize" "^1.10.1"
     "@noble/curves" "^1.6.0"
@@ -16969,20 +16983,19 @@ victory@^36.9.2:
     victory-voronoi-container "^36.9.2"
     victory-zoom-container "^36.9.2"
 
-viem@^2.21.55:
-  version "2.21.55"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.55.tgz#a57ad31fcf2a0f6c011b1909f02c94421ec4f781"
-  integrity sha512-PgXew7C11cAuEtOSgRyQx2kJxEOPUwIwZA9dMglRByqJuFVA7wSGZZOOo/93iylAA8E15bEdqy9xulU3oKZ70Q==
+viem@^2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.24.1.tgz#5fe8a78f535aa7b585bef8abd6addb3aa674a4d1"
+  integrity sha512-xptFlc081SIPz+ZNDeb0XS/Nn5PU28onq+im+UxEAPCXTIuL1kfw1GTnV8NhbUNoEONnrwcZNqoI0AT0ADF5XQ==
   dependencies:
-    "@noble/curves" "1.7.0"
-    "@noble/hashes" "1.6.1"
-    "@scure/bip32" "1.6.0"
-    "@scure/bip39" "1.5.0"
-    abitype "1.0.7"
+    "@noble/curves" "1.8.1"
+    "@noble/hashes" "1.7.1"
+    "@scure/bip32" "1.6.2"
+    "@scure/bip39" "1.5.4"
+    abitype "1.0.8"
     isows "1.0.6"
-    ox "0.1.2"
-    webauthn-p256 "0.0.10"
-    ws "8.18.0"
+    ox "0.6.9"
+    ws "8.18.1"
 
 vlq@^0.2.1:
   version "0.2.3"
@@ -17061,14 +17074,6 @@ web3-validator@^2.0.6:
     web3-errors "^1.2.0"
     web3-types "^1.6.0"
     zod "^3.21.4"
-
-webauthn-p256@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/webauthn-p256/-/webauthn-p256-0.0.10.tgz#877e75abe8348d3e14485932968edf3325fd2fdd"
-  integrity sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==
-  dependencies:
-    "@noble/curves" "^1.4.0"
-    "@noble/hashes" "^1.4.0"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -17271,10 +17276,10 @@ ws@8.17.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
-ws@8.18.0, ws@^8.12.1:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@8.18.1:
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.1.tgz#ea131d3784e1dfdff91adb0a4a116b127515e3cb"
+  integrity sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==
 
 ws@^6.2.3:
   version "6.2.3"
@@ -17287,6 +17292,11 @@ ws@^7, ws@^7.0.0, ws@^7.5.1, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+ws@^8.12.1:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 xcode@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
### Description

This updates `estimateFeesPerGas` to use Celo's fee estimation implementation in viem without relying on `getGasPriceMinimum` which can't be used anymore following the L2 hardfork.

The added benefit is that it now follows the [baseFeeMultiplier](https://rc.viem.sh/docs/clients/chains.html#fees-basefeemultiplier) applied by viem and should be more future proof.

The `baseFeePerGas` is captured in a hacky way, but unit tests are present to ensure it will keep working as expected.

Viem was updated so we get the latest implementation for `estimateFeesPerGas` on Celo L2.

### Test plan

- Updated tests
- Manually tested the network fees are correct with different fee currencies.

### Related issues

- N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
