### PR TITLE
feat(swap): implement slide button

### DIFF
--- a/packages/@divvi/mobile/__mocks__/src/swap/UnfavorableRateBottomSheet.tsx
+++ b/packages/@divvi/mobile/__mocks__/src/swap/UnfavorableRateBottomSheet.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { TouchableOpacity, View } from 'react-native'
+
+export default function UnfavorableRateBottomSheet({
+  onConfirm,
+  onCancel,
+}: {
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  return (
+    <View>
+      <TouchableOpacity onPress={onCancel} testID="unfavorable-rate-cancel">
+        <View />
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onConfirm} testID="unfavorable-rate-confirm">
+        <View />
+      </TouchableOpacity>
+    </View>
+  )
+}

--- a/packages/@divvi/mobile/locales/base/translation.json
+++ b/packages/@divvi/mobile/locales/base/translation.json
@@ -1908,7 +1908,8 @@
     "title": "Are you sure?",
     "description": "You are about to make a very unfavorable swap. Please confirm that you would like to complete the swap.",
     "cancel": "Cancel",
-    "confirm": "Slide to Swap"
+    "confirm": "Slide to Swap",
+    "confirmed": "Swap Confirmed"
   },
   "swapTransactionDetailPage": {
     "swapFrom": "Swap from",

--- a/packages/@divvi/mobile/src/swap/SwapScreenV2.test.tsx
+++ b/packages/@divvi/mobile/src/swap/SwapScreenV2.test.tsx
@@ -1432,7 +1432,7 @@ describe('SwapScreen', () => {
     })
 
     it('pressing cancel fires analytics and does nothing else', async () => {
-      const { getByText, store, swapScreen } = renderScreen({})
+      const { getByText, getByTestId, store, swapScreen } = renderScreen({})
 
       selectSwapTokens('CELO', 'cUSD', swapScreen)
       await selectMaxFromAmount(swapScreen)
@@ -1442,7 +1442,7 @@ describe('SwapScreen', () => {
       })
       fireEvent.press(getByText('swapScreen.confirmSwap'))
 
-      fireEvent.press(getByText('swapUnfavorableRateBottomSheet.cancel'))
+      fireEvent.press(getByTestId('unfavorable-rate-cancel'))
 
       expect(store.getActions()).toEqual([])
       expect(AppAnalytics.track).toHaveBeenCalledWith(
@@ -1454,7 +1454,7 @@ describe('SwapScreen', () => {
     it('selecting confirm and submits the swap', async () => {
       const quoteReceivedTimestamp = 1000
       jest.spyOn(Date, 'now').mockReturnValue(quoteReceivedTimestamp) // quote received timestamp
-      const { getByText, store, swapScreen, swapFromContainer } = renderScreen({})
+      const { getByText, getByTestId, store, swapScreen, swapFromContainer } = renderScreen({})
 
       selectSwapTokens('CELO', 'cUSD', swapScreen)
       fireEvent.changeText(
@@ -1467,7 +1467,7 @@ describe('SwapScreen', () => {
       })
       fireEvent.press(getByText('swapScreen.confirmSwap'))
 
-      fireEvent.press(getByText('swapUnfavorableRateBottomSheet.confirm'))
+      fireEvent.press(getByTestId('unfavorable-rate-confirm'))
 
       expect(store.getActions()).toEqual(
         expect.arrayContaining([

--- a/packages/@divvi/mobile/src/swap/SwapScreenV2.tsx
+++ b/packages/@divvi/mobile/src/swap/SwapScreenV2.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { TextInput as RNTextInput, StyleSheet, Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
@@ -456,7 +456,7 @@ export default function SwapScreenV2({ route }: Props) {
     })
   }
 
-  function submitSwap() {
+  const submitSwap = useCallback(() => {
     if (!quote) {
       return // this should never happen, because the button must be disabled in that cases
     }
@@ -544,7 +544,7 @@ export default function SwapScreenV2({ route }: Props) {
         const assertNever: never = resultType
         return assertNever
     }
-  }
+  }, [quote, processedAmountsFrom, processedAmountsTo, showUnfavorableRateConfirmation, tokensById])
 
   function handleConfirmSwap() {
     if (!quote) {
@@ -584,7 +584,7 @@ export default function SwapScreenV2({ route }: Props) {
     submitSwap()
   }
 
-  function handleUnfavorableRateBottomSheetCancel() {
+  const handleUnfavorableRateBottomSheetCancel = useCallback(() => {
     if (!quote) {
       return // this should never happen, because swap confirmation button is disabled in that case
     }
@@ -613,7 +613,7 @@ export default function SwapScreenV2({ route }: Props) {
       provider: quote.provider,
       swapType: quote.swapType,
     })
-  }
+  }, [quote, processedAmountsFrom, processedAmountsTo, tokensById])
 
   function handleSwitchTokens() {
     AppAnalytics.track(SwapEvents.swap_switch_tokens, {

--- a/packages/@divvi/mobile/src/swap/UnfavorableRateBottomSheet.tsx
+++ b/packages/@divvi/mobile/src/swap/UnfavorableRateBottomSheet.tsx
@@ -1,17 +1,21 @@
 import { BigNumber } from 'bignumber.js'
-import React, { RefObject } from 'react'
+import React, { RefObject, useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { Animated, PanResponder, StyleSheet, Text, View } from 'react-native'
 import BottomSheet, { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { formatValueToDisplay } from 'src/components/TokenDisplay'
 import ArrowRightThick from 'src/icons/ArrowRightThick'
+import Checkmark from 'src/icons/Checkmark'
+import ForwardChevron from 'src/icons/ForwardChevron'
 import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
 import { useSelector } from 'src/redux/hooks'
-import colors from 'src/styles/colors'
+import { default as Colors, default as colors } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { TokenBalance } from 'src/tokens/slice'
+
+const BUTTON_HEIGHT = 56
 
 export default function UnfavorableRateBottomSheet({
   forwardedRef,
@@ -91,18 +95,109 @@ export default function UnfavorableRateBottomSheet({
           type={BtnTypes.PRIMARY}
           size={BtnSizes.FULL}
           text={t('swapUnfavorableRateBottomSheet.cancel')}
+          touchableStyle={{ height: BUTTON_HEIGHT }}
         />
-        <Button
-          onPress={() => {
+        <SlideButton
+          onComplete={() => {
             forwardedRef.current?.close()
             onConfirm()
           }}
-          type={BtnTypes.SECONDARY}
-          size={BtnSizes.FULL}
-          text={t('swapUnfavorableRateBottomSheet.confirm')}
         />
       </View>
     </BottomSheet>
+  )
+}
+
+const SlideButton = ({ onComplete }: { onComplete: () => void }) => {
+  const { t } = useTranslation()
+  const slideThreshold = useRef(1)
+  const pan = useRef(new Animated.Value(0)).current
+  const [completed, setCompleted] = useState(false)
+
+  const onCompleteRef = useRef(onComplete)
+
+  // ensure the latest onComplete is used by the pan responder
+  useEffect(() => {
+    onCompleteRef.current = onComplete
+  }, [onComplete])
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: () => !completed,
+      onPanResponderMove: Animated.event([null, { dx: pan }], { useNativeDriver: false }),
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dx > slideThreshold.current) {
+          Animated.timing(pan, {
+            toValue: slideThreshold.current,
+            duration: 50,
+            useNativeDriver: false,
+          }).start(() => {
+            setCompleted(true)
+            // delay the onComplete to allow the user to see the checkmark
+            setTimeout(onCompleteRef.current, 500)
+            // reset after a second to allow the user to slide again in case the
+            // transaction submission fails
+            setTimeout(() => {
+              setCompleted(false)
+              pan.setValue(0)
+            }, 1000)
+          })
+        } else {
+          Animated.spring(pan, {
+            toValue: 0,
+            useNativeDriver: false,
+          }).start()
+        }
+      },
+    })
+  ).current
+
+  return (
+    <View
+      style={[
+        styles.slideButtonContainer,
+        completed
+          ? { backgroundColor: Colors.buttonSecondaryBackground }
+          : { backgroundColor: Colors.buttonTertiaryBackground },
+      ]}
+      onLayout={(event) => {
+        const { width } = event.nativeEvent.layout
+        // threshold is the left edge of the slider, so we need to subtract the
+        // width of the slider which is same as the height of the button
+        slideThreshold.current = width - BUTTON_HEIGHT
+      }}
+      testID="SlideButton"
+    >
+      <Text style={styles.slideButtonText}>
+        {completed
+          ? t('swapUnfavorableRateBottomSheet.confirmed')
+          : t('swapUnfavorableRateBottomSheet.confirm')}
+      </Text>
+      <Animated.View
+        {...panResponder.panHandlers}
+        style={[
+          styles.slider,
+          {
+            transform: [
+              {
+                translateX: pan.interpolate({
+                  inputRange: [0, slideThreshold.current],
+                  outputRange: [0, slideThreshold.current],
+                  extrapolate: 'clamp',
+                }),
+              },
+            ],
+          },
+        ]}
+        testID="SlideButton/Slider"
+      >
+        {!completed ? (
+          <ForwardChevron color={Colors.contentTertiary} />
+        ) : (
+          <Checkmark height={24} width={24} color={Colors.contentTertiary} />
+        )}
+      </Animated.View>
+    </View>
   )
 }
 
@@ -122,5 +217,32 @@ const styles = StyleSheet.create({
   },
   buttonContainer: {
     gap: Spacing.Small12,
+  },
+  slideButtonContainer: {
+    borderWidth: 1,
+    borderColor: Colors.buttonTertiaryBorder,
+    borderRadius: 30,
+    justifyContent: 'center',
+    overflow: 'hidden',
+    width: '100%',
+    height: BUTTON_HEIGHT,
+  },
+  slideButtonText: {
+    ...typeScale.labelSemiBoldMedium,
+    position: 'absolute',
+    width: '100%',
+    textAlign: 'center',
+    color: Colors.buttonSecondaryContent,
+  },
+  slider: {
+    backgroundColor: Array.isArray(Colors.buttonPrimaryBackground)
+      ? Colors.buttonPrimaryBackground[0]
+      : Colors.buttonPrimaryBackground,
+    width: 40, // Reduced width slightly due to margin
+    height: 40, // Reduced height slightly due to margin
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    margin: Spacing.Smallest8,
   },
 })


### PR DESCRIPTION
### Description

Part 2 of ENG-209, implement the slide button for confirming unfavorable swaps

### Test plan

Manually by forcing the bottom sheet by updating the threshold on statsig defaults (e.g., setting to 1.1)
(Fonts don't match designs as the example app doesn't use the Inter font from Valora)

[android-swap-bottomsheet.webm](https://github.com/user-attachments/assets/8fba50fd-59b2-4048-bae2-d6a6288282e2)

https://github.com/user-attachments/assets/2d4736b6-b582-4381-9f81-5dd0b331b5bf

### Related issues

- Fixes ENG-209

### Backwards compatibility

Yes

