### PR TITLE
fix(sentry): add sentry plumbing

### DIFF
--- a/packages/@divvi/mobile/metro-config.js
+++ b/packages/@divvi/mobile/metro-config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig: getDefaultConfigExpo } = require('expo/metro-config')
+const { withSentryConfig } = require('@sentry/react-native/metro')
 
 // Wraps Expo's getDefaultConfig to add our customizations
 function getDefaultConfig(...args) {
@@ -34,7 +35,7 @@ function getDefaultConfig(...args) {
     return context.resolveRequest(context, moduleName, platform)
   }
 
-  return config
+  return withSentryConfig(config)
 }
 
 module.exports = { getDefaultConfig }

--- a/packages/@divvi/mobile/plugin/src/index.ts
+++ b/packages/@divvi/mobile/plugin/src/index.ts
@@ -19,7 +19,9 @@ const withMobileApp: ConfigPlugin<{
 }> = (config, props = {}) => {
   return withPlugins(config, [
     // Sentry
-    [withSentry, props.sentry ?? {}],
+    ...((props.sentry
+      ? [withSentry, props.sentry ?? {}]
+      : []) as ConfigPlugin<SentryPluginProps>[]),
 
     // iOS
     withIosAppDelegateResetKeychain,

--- a/packages/@divvi/mobile/plugin/src/index.ts
+++ b/packages/@divvi/mobile/plugin/src/index.ts
@@ -1,16 +1,26 @@
 import { ConfigPlugin, withPlugins } from '@expo/config-plugins'
 
+import { withSentry } from '@sentry/react-native/expo'
+
 import { withAndroidCameraBuildFix } from './withAndroidCameraBuildFix'
 import { withAndroidUserAgent } from './withAndroidUserAgent'
 import { withAndroidWindowSoftInputModeAdjustNothing } from './withAndroidWindowSoftInputModeAdjustNothing'
 import { withIosAppDelegateResetKeychain } from './withIosAppDelegateResetKeychain'
 import { withIosUserAgent } from './withIosUserAgent'
 
+type SentryPluginProps = Parameters<typeof withSentry>[1]
+
 /**
  * A config plugin for configuring `@divvi/mobile`
  */
-const withMobileApp: ConfigPlugin<{ appName?: string }> = (config, props = {}) => {
+const withMobileApp: ConfigPlugin<{
+  appName?: string
+  sentry?: SentryPluginProps
+}> = (config, props = {}) => {
   return withPlugins(config, [
+    // Sentry
+    [withSentry, props.sentry ?? {}],
+
     // iOS
     withIosAppDelegateResetKeychain,
     [withIosUserAgent, props],

--- a/packages/@divvi/mobile/plugin/src/index.ts
+++ b/packages/@divvi/mobile/plugin/src/index.ts
@@ -19,9 +19,7 @@ const withMobileApp: ConfigPlugin<{
 }> = (config, props = {}) => {
   return withPlugins(config, [
     // Sentry
-    ...((props.sentry
-      ? [withSentry, props.sentry ?? {}]
-      : []) as ConfigPlugin<SentryPluginProps>[]),
+    ...((props.sentry ? [withSentry, props.sentry] : []) as ConfigPlugin<SentryPluginProps>[]),
 
     // iOS
     withIosAppDelegateResetKeychain,


### PR DESCRIPTION
### Description

We noticed that the releases built with EAS aren't added to Sentry automatically.

The Sentry and Expo docs suggest that additional plumbing is needed:
https://docs.sentry.io/platforms/react-native/sourcemaps/uploading/expo/
https://docs.expo.dev/guides/using-sentry/

This (hopefully) fixes the issue. However, I have no idea how to test it other than trigger a new build on a Sentry-enabled app.

### Test plan

* CI
* Next wallet build

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

NA