### PR TITLE
test(e2e): fix failing dapps list test

### DIFF
--- a/apps/example/e2e/src/usecases/DappListDisplay.js
+++ b/apps/example/e2e/src/usecases/DappListDisplay.js
@@ -9,10 +9,10 @@ export default DappListDisplay = () => {
   beforeAll(async () => {
     dappList = await fetchDappList()
     dappToTest = {
-      dapp: dappList.applications.find((dapp) => dapp.id === 'nftviewer'),
+      dapp: dappList.applications.find((dapp) => dapp.id === 'uniswap'),
       index: dappList.applications
         .filter((dapp) => dapp[device.getPlatform() === 'ios' ? 'listOnIos' : 'listOnAndroid'])
-        .findIndex((dapp) => dapp.id === 'nftviewer'),
+        .findIndex((dapp) => dapp.id === 'uniswap'),
     }
   })
 


### PR DESCRIPTION
I removed the NFT viewer dapp in https://github.com/valora-inc/dapp-list/pull/724
And didn't realize it would break the e2e test.
This fixes it.