### PR TITLE
fix(shortcuts): error when claiming reward when extra divvi registration is needed

### DIFF
--- a/packages/@divvi/mobile/src/positions/saga.ts
+++ b/packages/@divvi/mobile/src/positions/saga.ts
@@ -6,6 +6,7 @@ import AppAnalytics from 'src/analytics/AppAnalytics'
 import { BuilderHooksEvents, DappShortcutsEvents } from 'src/analytics/Events'
 import { HooksEnablePreviewOrigin } from 'src/analytics/types'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { isRegistrationTransaction } from 'src/divviProtocol/registerReferral'
 import i18n from 'src/i18n'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import { isBottomSheetVisible, navigateBack } from 'src/navigator/NavigationService'
@@ -324,7 +325,7 @@ export function* executeShortcutSaga({
       shortcut.networkId,
       // We can't really create standby transactions for shortcuts
       // since we don't have the necessary information
-      preparedTransactions.map(() => () => null)
+      preparedTransactions.filter((tx) => !isRegistrationTransaction(tx)).map(() => () => null)
     )
 
     yield* put(executeShortcutSuccess(id))


### PR DESCRIPTION
### Description

This fixes an error when claiming rewards from shortcuts, when an extra divvi registration is also needed.

`prepareTransactions` was updated in https://github.com/valora-inc/wallet/pull/6492 to insert a Divvi registration when needed.
However `sendPreparedTransactions` filters out the Divvi registration and then checks the `createBaseStandbyTransactions` array is the same length as the filtered transactions. And throws if they don't match.

All call sites where updated to account for this "surprising" behavior, except one that was missed, which handles shortcuts rewards claiming.

Note: we'll soon revamp this part with the new Divvi registration flow where no extra TX will be needed. This will remove these "surprising" behaviors. I omitted an extra unit test for this reason too.

### Test plan

- Manually tested claiming a reward works when an extra Divvi registration is needed

### Related issues

- See Slack [thread](https://valora-app.slack.com/archives/C04B61SJ6DS/p1744822525875159).

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
