### PR TITLE
chore(deps): re-enable renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,4 @@
 {
-  // Temporarily disable Renovate in this repo until it's ready to be the main source of development
-  // to avoid conflicts and duplicated PRs, while still syncing from the wallet repo
-  enabled: false,
   extends: ['github>valora-inc/renovate-config:default.json5', ':disableDigestUpdates'],
 
   // Restrict semantic commit type to "chore"


### PR DESCRIPTION
### Description

We temporarily disabled Renovate while we had to sync the incoming changes from the wallet repo. Now when the detachement is complete, we can try to re-enable Renovate.

### Test plan

CI

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA