### PR TITLE
fix: reset onboarding on error

### DIFF
--- a/packages/@divvi/mobile/src/account/AccountSetupFailureScreen.test.tsx
+++ b/packages/@divvi/mobile/src/account/AccountSetupFailureScreen.test.tsx
@@ -1,9 +1,25 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import RNExitApp from 'react-native-exit-app'
+import { Provider } from 'react-redux'
 import AccounSetupFailureScreen from 'src/account/AccountSetupFailureScreen'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { updateLastOnboardingScreen } from 'src/onboarding/actions'
+import { createMockStore } from 'test/utils'
+
+function renderScreen() {
+  const store = createMockStore()
+  const renderResult = render(
+    <Provider store={store}>
+      <AccounSetupFailureScreen />
+    </Provider>
+  )
+  return {
+    ...renderResult,
+    store,
+  }
+}
 
 describe('AccountSetupFailureScreen', () => {
   beforeEach(() => {
@@ -11,7 +27,7 @@ describe('AccountSetupFailureScreen', () => {
   })
 
   it('should render the correct elements', () => {
-    const { getByText } = render(<AccounSetupFailureScreen />)
+    const { getByText } = renderScreen()
 
     expect(getByText('accountSetupFailed')).toBeTruthy()
     expect(getByText('accountSetupFailedDescription')).toBeTruthy()
@@ -20,7 +36,7 @@ describe('AccountSetupFailureScreen', () => {
   })
 
   it('should handle closing the app', () => {
-    const { getByText } = render(<AccounSetupFailureScreen />)
+    const { getByText } = renderScreen()
 
     fireEvent.press(getByText('closeApp'))
 
@@ -28,10 +44,16 @@ describe('AccountSetupFailureScreen', () => {
   })
 
   it('should handle contact support', () => {
-    const { getByText } = render(<AccounSetupFailureScreen />)
+    const { getByText } = renderScreen()
 
     fireEvent.press(getByText('contactSupport'))
 
     expect(navigate).toHaveBeenCalledWith(Screens.SupportContact)
+  })
+
+  it('should dispatch updateLastOnboardingScreen on mount', () => {
+    const { store } = renderScreen()
+
+    expect(store.getActions()).toEqual([updateLastOnboardingScreen(Screens.Welcome)])
   })
 })

--- a/packages/@divvi/mobile/src/account/AccountSetupFailureScreen.tsx
+++ b/packages/@divvi/mobile/src/account/AccountSetupFailureScreen.tsx
@@ -1,13 +1,20 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import RNExitApp from 'react-native-exit-app'
 import AccountErrorScreen from 'src/account/AccountErrorScreen'
 import { noHeaderGestureDisabled } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { updateLastOnboardingScreen } from 'src/onboarding/actions'
+import { useDispatch } from 'src/redux/hooks'
 
 function AccounSetupFailureScreen() {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    dispatch(updateLastOnboardingScreen(Screens.Welcome)) // reset onboarding flow
+  }, [])
 
   const onPressCloseApp = () => {
     RNExitApp.exitApp()

--- a/packages/@divvi/mobile/src/onboarding/steps.ts
+++ b/packages/@divvi/mobile/src/onboarding/steps.ts
@@ -256,12 +256,12 @@ function _getStepInfo({ firstScreenInStep, navigator, dispatch, props }: GetStep
         origin: KeylessBackupOrigin.Onboarding,
       })
     } else {
-      dispatch(initializeAccount())
       if (skipProtectWallet) {
         navigateToPhoneVerificationOrFinish()
       } else {
         wrapNavigate(Screens.ProtectWallet)
       }
+      dispatch(initializeAccount())
     }
   }
 


### PR DESCRIPTION
### Description

When an error happens during onboarding, the app is stuck on the onboarding step.

#### Reproduction example
1. Simulate error by adding `throw new Error('Test')` to [retrieveOrGeneratePepper()](https://github.com/divvi-xyz/divvi-mobile/blob/8de409e01d6b0757e5d5a32a024c6f1134eb13d5/packages/%40divvi/mobile/src/pincode/authentication.ts#L84) function
2. Start onboarding and observe the error
3. Restart the app
4. Observe the stuck state

#### Expected behavior
After restarting, the app is returned to the Welcome screen.

#### Workaround

Users can reinstall the app / clear app data 

### Test plan

* CI
* Added unit test
* Tested manually

### Related issues

- Related to ENG-300

### Backwards compatibility

Y

### Network scalability

NA