### PR TITLE
fix(ci): ensure we scroll to the asset we tap

### DIFF
--- a/apps/example/e2e/src/usecases/Assets.js
+++ b/apps/example/e2e/src/usecases/Assets.js
@@ -101,9 +101,7 @@ export default Assets = () => {
 
     describe.each(tokens)('For $symbol', ({ symbol, tokenId, learnMore, actions, moreActions }) => {
       it('navigates to asset details on tapping asset', async () => {
-        const itemId = `TokenBalanceItemTouchable/${tokenId}`
-        await scrollIntoViewByTestId(itemId)
-        await element(by.id(itemId)).tap()
+        await waitForElementById(`TokenBalanceItemTouchable/${tokenId}`, { tap: true })
         await waitForElementById('TokenDetails/AssetValue')
       })
 

--- a/apps/example/e2e/src/usecases/Assets.js
+++ b/apps/example/e2e/src/usecases/Assets.js
@@ -101,8 +101,9 @@ export default Assets = () => {
 
     describe.each(tokens)('For $symbol', ({ symbol, tokenId, learnMore, actions, moreActions }) => {
       it('navigates to asset details on tapping asset', async () => {
-        await element(by.id('Assets/SectionList')).scrollTo('bottom')
-        await waitForElementById(`TokenBalanceItemTouchable/${tokenId}`, { tap: true })
+        const elementId = `TokenBalanceItemTouchable/${tokenId}`
+        await scrollIntoView(elementId, 'Assets/SectionList')
+        await element(by.id(elementId)).tap()
         await waitForElementById('TokenDetails/AssetValue')
       })
 

--- a/apps/example/e2e/src/usecases/Assets.js
+++ b/apps/example/e2e/src/usecases/Assets.js
@@ -101,7 +101,9 @@ export default Assets = () => {
 
     describe.each(tokens)('For $symbol', ({ symbol, tokenId, learnMore, actions, moreActions }) => {
       it('navigates to asset details on tapping asset', async () => {
-        await waitForElementById(`TokenBalanceItemTouchable/${tokenId}`, { tap: true })
+        const itemId = `TokenBalanceItemTouchable/${tokenId}`
+        await scrollIntoViewByTestId(itemId)
+        await element(by.id(itemId)).tap()
         await waitForElementById('TokenDetails/AssetValue')
       })
 

--- a/apps/example/e2e/src/usecases/Assets.js
+++ b/apps/example/e2e/src/usecases/Assets.js
@@ -101,6 +101,7 @@ export default Assets = () => {
 
     describe.each(tokens)('For $symbol', ({ symbol, tokenId, learnMore, actions, moreActions }) => {
       it('navigates to asset details on tapping asset', async () => {
+        await element(by.id('Assets/SectionList')).scrollTo('bottom')
         await waitForElementById(`TokenBalanceItemTouchable/${tokenId}`, { tap: true })
         await waitForElementById('TokenDetails/AssetValue')
       })

--- a/apps/example/e2e/src/usecases/Assets.js
+++ b/apps/example/e2e/src/usecases/Assets.js
@@ -102,7 +102,7 @@ export default Assets = () => {
     describe.each(tokens)('For $symbol', ({ symbol, tokenId, learnMore, actions, moreActions }) => {
       it('navigates to asset details on tapping asset', async () => {
         const elementId = `TokenBalanceItemTouchable/${tokenId}`
-        await scrollIntoView(elementId, 'Assets/SectionList')
+        await scrollIntoViewByTestId(elementId, 'Assets/SectionList')
         await element(by.id(elementId)).tap()
         await waitForElementById('TokenDetails/AssetValue')
       })

--- a/packages/@divvi/mobile/src/tokens/AssetList.tsx
+++ b/packages/@divvi/mobile/src/tokens/AssetList.tsx
@@ -273,6 +273,7 @@ export default function AssetList({
 
   return (
     <AnimatedSectionList
+      testID="Assets/SectionList"
       contentContainerStyle={[
         { minHeight: variables.height, opacity: listHeaderHeight > 0 ? 1 : 0 },
         activeTab === AssetTabType.Collectibles &&


### PR DESCRIPTION
### Description

As the asset list on the test account grows, some items we tap on during the E2E test may not be visible.

This ensures the item is scrolled into view before the tap.

Context: The asset list went bigger, because I added some ETH on Optimism to burn unwanted spam NFTs that also blocked the CI. See also #211 

### Test plan

CI

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA