### PR TITLE
feat: divvi slices bottom sheet remote config

### DIFF
--- a/packages/@divvi/mobile/src/statsig/constants.ts
+++ b/packages/@divvi/mobile/src/statsig/constants.ts
@@ -33,6 +33,7 @@ export const FeatureGates = {
   [StatsigFeatureGates.SHOW_NEW_ENTER_AMOUNT_FOR_SWAP]: true,
   [StatsigFeatureGates.ALLOW_CROSS_CHAIN_SWAP_AND_DEPOSIT]: false,
   [StatsigFeatureGates.DISABLE_WALLET_CONNECT_V2]: false,
+  [StatsigFeatureGates.SHOW_DIVVI_SLICES_BOTTOM_SHEET]: false,
 } satisfies { [key in StatsigFeatureGates]: boolean }
 
 export const ExperimentConfigs = {
@@ -161,6 +162,10 @@ export const DynamicConfigs = {
     defaultValues: {
       inviteRewardsVersion: 'none',
     },
+  },
+  [StatsigDynamicConfigs.DIVVI_SLICES_BOTTOM_SHEET_CONFIG]: {
+    configName: StatsigDynamicConfigs.DIVVI_SLICES_BOTTOM_SHEET_CONFIG,
+    defaultValues: {} as { url?: string },
   },
 } satisfies {
   [key in StatsigDynamicConfigs]: {

--- a/packages/@divvi/mobile/src/statsig/types.ts
+++ b/packages/@divvi/mobile/src/statsig/types.ts
@@ -11,6 +11,7 @@ export enum StatsigDynamicConfigs {
   DEMO_MODE_CONFIG = 'demo_mode_config',
   FIAT_CONNECT_CONFIG = 'fiat_connect_config',
   INVITE_REWARDS_CONFIG = 'invite_rewards_config',
+  DIVVI_SLICES_BOTTOM_SHEET_CONFIG = 'divvi_slices_bottom_sheet_config',
 }
 
 export enum StatsigFeatureGates {
@@ -34,6 +35,7 @@ export enum StatsigFeatureGates {
   SHOW_NEW_ENTER_AMOUNT_FOR_SWAP = 'show_new_enter_amount_for_swap',
   ALLOW_CROSS_CHAIN_SWAP_AND_DEPOSIT = 'allow_cross_chain_swap_and_deposit',
   DISABLE_WALLET_CONNECT_V2 = 'disable_wallet_connect_v2',
+  SHOW_DIVVI_SLICES_BOTTOM_SHEET = 'show_divvi_slices_bottom_sheet',
 }
 
 export enum StatsigExperiments {


### PR DESCRIPTION
### Description

Plumbing to fetch divvi slices bottom sheet remote config:
* whether it is enabled
* url to take the user to

### Test plan

- Expected to be applied in ENG-360

### Related issues

- Fixes ENG-359

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
