### PR TITLE
chore(deps): upgrade react-native-safe-area-context to 5.5.1

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -79,7 +79,7 @@
     "react-native-quick-crypto": "0.7.7",
     "react-native-reanimated": "^3.15.1",
     "react-native-restart": "^0.0.27",
-    "react-native-safe-area-context": "^4.14.1",
+    "react-native-safe-area-context": "^5.5.1",
     "react-native-screens": "^4.3.0",
     "react-native-shake": "5.5.2",
     "react-native-share": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "react-native-quick-crypto": "0.7.7",
     "react-native-reanimated": "^3.15.1",
     "react-native-restart": "^0.0.27",
-    "react-native-safe-area-context": "^4.14.1",
+    "react-native-safe-area-context": "^5.5.1",
     "react-native-screens": "^4.3.0",
     "react-native-shake": "5.5.2",
     "react-native-share": "^11.1.0",

--- a/packages/@divvi/mobile/package.json
+++ b/packages/@divvi/mobile/package.json
@@ -113,7 +113,7 @@
     "react-native-quick-crypto": "0.7.7",
     "react-native-reanimated": "^3.15.1",
     "react-native-restart": "^0.0.27",
-    "react-native-safe-area-context": "^4.14.1",
+    "react-native-safe-area-context": "^5.5.1",
     "react-native-screens": "^4.3.0",
     "react-native-shake": "5.5.2",
     "react-native-share": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14138,10 +14138,10 @@ react-native-restart@^0.0.27:
   resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.27.tgz#43aa8210312c9dfa5ec7bd4b2f35238ad7972b19"
   integrity sha512-8KScVICrXwcTSJ1rjWkqVTHyEKQIttm5AIMGSK1QG1+RS5owYlE4z/1DykOTdWfVl9l16FIk0w9Xzk9ZO6jxlA==
 
-react-native-safe-area-context@^4.14.1:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.14.1.tgz#980c3c9db02a2314fa8ceb07f614728802320367"
-  integrity sha512-+tUhT5WBl8nh5+P+chYhAjR470iCByf9z5EYdCEbPaAK3Yfzw+o8VRPnUgmPAKlSccOgQBxx3NOl/Wzckn9ujg==
+react-native-safe-area-context@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.5.1.tgz#9fac8ae5da8b9ff6f77eb3f697e073f04a1f2f3f"
+  integrity sha512-WYxV+mm7SWuapVWxq2071lkQlDUXjSwcu7Cc2bUtNcF80/Bl0WnuWAZ8+tO46M38PclMrQIIgbv83BvDHJNQ5g==
 
 react-native-safe-modules@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
### Description

Upgrades react-native-safe-area-context to [5.5.1](https://github.com/AppAndFlow/react-native-safe-area-context/releases/tag/v5.5.1)

### Test plan

- [ ] Tested locally on iOS
- [ ] Tested locally on Android

### Related issues

- ENG-491

### Backwards compatibility

Yes

### Network scalability

N/A
