### PR TITLE
ci(e2e): set min balance for e2e accounts to 20 per token

### DIFF
--- a/apps/example/e2e/scripts/fund-e2e-accounts.ts
+++ b/apps/example/e2e/scripts/fund-e2e-accounts.ts
@@ -170,7 +170,7 @@ const valoraTestFaucetSecret = process.env['E2E_TEST_FAUCET_SECRET']!
 
   // Set Amount To Send
   const amountToSend = '6'
-  const minBalance = 12
+  const minBalance = 20
 
   for (let i = 0; i < walletsToBeFunded.length; i++) {
     const walletAddress = walletsToBeFunded[i]


### PR DESCRIPTION
### Description

E2E tests rely on checking for providers of up to 20 select tokens.

### Test plan

- [x] Tested in CI - https://github.com/divvi-xyz/divvi-mobile/actions/runs/16159574654

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
