### PR TITLE
fix(nfts): align correctly when there are partial load errors

### DIFF
--- a/packages/@divvi/mobile/src/tokens/AssetList.tsx
+++ b/packages/@divvi/mobile/src/tokens/AssetList.tsx
@@ -209,8 +209,13 @@ export default function AssetList({
   }
 
   const NftGroup = ({ item }: { item: NftWithNetworkId[] }) => {
+    const isSingleItem = item.length === 1
+
     return (
-      <View testID="NftGroup" style={styles.nftsPairingContainer}>
+      <View testID="NftGroup" style={[
+        styles.nftsPairingContainer,
+        isSingleItem && styles.nftSingleItem
+        ]}>
         {item.map((nft, index) => (
           <NftItem key={index} item={nft} />
         ))}
@@ -220,7 +225,6 @@ export default function AssetList({
 
   const renderAssetItem = ({
     item,
-    index,
   }: {
     item: TokenBalance | Position | NftWithNetworkId[]
     index: number
@@ -338,12 +342,17 @@ const styles = StyleSheet.create({
   positionSectionHeaderText: {
     ...typeScale.labelXXSmall,
   },
+  nftSingleItem: {
+    justifyContent: 'flex-start', 
+    marginLeft: Spacing.Thick24 
+  },
   nftsPairingContainer: {
     flexDirection: 'row',
     gap: Spacing.Regular16,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   nftsContentContainer: {
-    alignItems: 'flex-start',
     paddingHorizontal: Spacing.Thick24,
   },
   nftsErrorView: {


### PR DESCRIPTION
### Description

Before this PR, when NFTs could fail to load, there would be a misalignment of NFT items.

| Before | After |
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/08b161d7-32d1-434a-8a18-b97090ad77fb) | ![](https://github.com/user-attachments/assets/192b4504-2ed9-4306-9f01-89ba01920dda) |

### Test plan

- [x] Tested locally on iOS
- [ ] Tested locally on Android

### Related issues

- ENG-628

### Backwards compatibility

Yes

### Network scalability

N/A
