### PR TITLE
fix(android): avoid showing auth toggle which fails

### DIFF
--- a/packages/@divvi/mobile/src/pincode/authentication.ts
+++ b/packages/@divvi/mobile/src/pincode/authentication.ts
@@ -6,6 +6,7 @@
  */
 
 import crypto from 'crypto'
+import { Platform } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 import { PincodeType } from 'src/account/reducer'
 import { pincodeTypeSelector } from 'src/account/selectors'
@@ -135,7 +136,10 @@ function storePinWithBiometry(pin: string) {
     options: {
       // BIOMETRY_CURRENT_SET not working as intended on Android
       // https://github.com/oblador/react-native-keychain/issues/725
-      accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
+      accessControl:
+        Platform.OS === 'ios'
+          ? Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET
+          : Keychain.ACCESS_CONTROL.BIOMETRY_ANY_OR_DEVICE_PASSCODE,
       accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
       securityLevel: Keychain.SECURITY_LEVEL.SECURE_SOFTWARE,
     },

--- a/packages/@divvi/mobile/src/pincode/authentication.ts
+++ b/packages/@divvi/mobile/src/pincode/authentication.ts
@@ -6,7 +6,6 @@
  */
 
 import crypto from 'crypto'
-import { Platform } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 import { PincodeType } from 'src/account/reducer'
 import { pincodeTypeSelector } from 'src/account/selectors'
@@ -136,10 +135,7 @@ function storePinWithBiometry(pin: string) {
     options: {
       // BIOMETRY_CURRENT_SET not working as intended on Android
       // https://github.com/oblador/react-native-keychain/issues/725
-      accessControl:
-        Platform.OS === 'ios'
-          ? Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET
-          : Keychain.ACCESS_CONTROL.BIOMETRY_ANY,
+      accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
       accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
       securityLevel: Keychain.SECURITY_LEVEL.SECURE_SOFTWARE,
     },


### PR DESCRIPTION
### Description

On Android with other biometrics options: `BIOMETRY_ANY` or `BIOMETRY_CURRENT_SET` a toggle is served allowing selection between using fingerprint or face ID if both are enabled on the devices; however, in testing face ID would always fail. 

### Test plan

- [x] Tested locally on Android

### Related issues

#238

### Backwards compatibility

Yes

### Network scalability

N/A
