### PR TITLE
fix(android): prevent headers from overlapping status bar

### DIFF
--- a/packages/@divvi/mobile/src/app/App.tsx
+++ b/packages/@divvi/mobile/src/app/App.tsx
@@ -7,7 +7,7 @@ import { LogBox, Platform, StatusBar } from 'react-native'
 import { Auth0Provider } from 'react-native-auth0'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { getNumberFormatSettings } from 'react-native-localize'
-import { initialWindowMetrics, SafeAreaProvider } from 'react-native-safe-area-context'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { enableFreeze, enableScreens } from 'react-native-screens'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
@@ -79,6 +79,7 @@ export class App extends React.Component<Props> {
   isConsumingInitialLink = false
   // TODO: add support for changing themes dynamically, here we are getting only the default theme colors.
   isDarkTheme = getAppConfig().themes?.default?.isDark
+  backgroundColor = getAppConfig().themes?.default?.colors?.backgroundPrimary
   isAndroid = Platform.OS === 'android'
 
   async componentDidMount() {
@@ -89,9 +90,7 @@ export class App extends React.Component<Props> {
 
   render() {
     return (
-      <SafeAreaProvider
-        style={Platform.OS === 'android' ? { marginTop: initialWindowMetrics?.insets.top } : {}}
-      >
+      <SafeAreaProvider>
         <Provider store={store}>
           <PersistGate persistor={persistor}>
             <Auth0Provider domain={AUTH0_DOMAIN} clientId={AUTH0_CLIENT_ID}>
@@ -100,9 +99,9 @@ export class App extends React.Component<Props> {
                 reactLoadTime={this.reactLoadTime}
               >
                 <StatusBar
-                  backgroundColor="transparent"
+                  backgroundColor={this.isAndroid ? this.backgroundColor : 'transparent'}
                   barStyle={this.isDarkTheme ? 'light-content' : 'dark-content'}
-                  translucent
+                  translucent={this.isAndroid ? false : true}
                 />
                 <ErrorBoundary>
                   <GestureHandlerRootView style={{ flex: 1 }}>


### PR DESCRIPTION
### Description

Conditionally sets transparency and background color for the StatusBar based on the Platform. The background color appears briefly at the top of the full-screen background while loading.

### Test plan

- [x] Tested locally on Android
- [x] Tested locally on iOS

| Android Before | Android After | iOS Before | iOS After |
| ----- | ----- | ----- | ----- |
| ![](https://github.com/user-attachments/assets/c73402f5-f251-486b-9ee1-888158181cf2) | ![](https://github.com/user-attachments/assets/03868456-256e-409e-8f73-48a796c1f7bc) | ![](https://github.com/user-attachments/assets/c1c7c3c1-270d-4eca-96cd-e959e4ee9dbc) | ![](https://github.com/user-attachments/assets/15eae07e-f2d6-4299-b3fc-80554be87a1b) | 

| Background Color Shown on Load |
| ----- | 
| <video src="https://github.com/user-attachments/assets/d52b9a4b-1fe9-4e70-8513-e697bec4cdae" /> |

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
