### PR TITLE
fix(android): add react-native-keychain patch

### DIFF
--- a/packages/@divvi/mobile/src/pincode/authentication.test.ts
+++ b/packages/@divvi/mobile/src/pincode/authentication.test.ts
@@ -309,7 +309,7 @@ describe(setPincodeWithBiometry, () => {
       mockPin,
       expect.objectContaining({
         service: 'PIN',
-        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY_OR_DEVICE_PASSCODE,
+        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
       })
     )
   })
@@ -334,7 +334,7 @@ describe(setPincodeWithBiometry, () => {
       mockPin,
       expect.objectContaining({
         service: 'PIN',
-        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY_OR_DEVICE_PASSCODE,
+        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
       })
     )
   })
@@ -450,7 +450,7 @@ describe(updatePin, () => {
       mockPin,
       expect.objectContaining({
         service: 'PIN',
-        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY_OR_DEVICE_PASSCODE,
+        accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
       })
     )
   })

--- a/packages/@divvi/mobile/src/pincode/authentication.ts
+++ b/packages/@divvi/mobile/src/pincode/authentication.ts
@@ -6,7 +6,6 @@
  */
 
 import crypto from 'crypto'
-import { Platform } from 'react-native'
 import * as Keychain from 'react-native-keychain'
 import { PincodeType } from 'src/account/reducer'
 import { pincodeTypeSelector } from 'src/account/selectors'
@@ -134,12 +133,7 @@ function storePinWithBiometry(pin: string) {
     key: STORAGE_KEYS.PIN,
     value: pin,
     options: {
-      // BIOMETRY_CURRENT_SET not working as intended on Android
-      // https://github.com/oblador/react-native-keychain/issues/725
-      accessControl:
-        Platform.OS === 'ios'
-          ? Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET
-          : Keychain.ACCESS_CONTROL.BIOMETRY_ANY_OR_DEVICE_PASSCODE,
+      accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
       accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
       securityLevel: Keychain.SECURITY_LEVEL.SECURE_SOFTWARE,
     },

--- a/patches/react-native-keychain+10.0.0.patch
+++ b/patches/react-native-keychain+10.0.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+index 722a5ed..688b734 100644
+--- a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt
++++ b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+@@ -766,6 +766,9 @@ class KeychainModule(reactContext: ReactApplicationContext) :
+         usePasscode ->
+           BiometricManager.Authenticators.DEVICE_CREDENTIAL
+ 
++        useBiometry ->
++          BiometricManager.Authenticators.BIOMETRIC_STRONG
++
+         else ->
+           null
+       }


### PR DESCRIPTION
### Description

Adds a patch to [react-native-keychain](https://github.com/oblador/react-native-keychain) to prevent Face ID from being served on Android. The same patch will need to be applied by the [wallet](https://github.com/valora-inc/wallet). Alternatively, we could move back to our [fork](https://github.com/mobilestack-xyz/react-native-keychain) and republish.

### Test plan

- [x] Tested locally on Android - Face ID prompt not served

### Related issues

- #238 
- https://github.com/oblador/react-native-keychain/pull/759

### Backwards compatibility

Yes

### Network scalability

N/A
