### PR TITLE
chore(deps): upgrade @react-native-async-storage/async-storage to 2.2.0

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -24,7 +24,7 @@
     "@divvi/mobile": "*",
     "@divvi/react-native-fs": "^2.20.1",
     "@interaxyz/react-native-webview": "^13.13.4",
-    "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.1",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-firebase/analytics": "22.4.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@divvi/cookies": "^6.2.3",
     "@divvi/react-native-fs": "^2.20.1",
     "@interaxyz/react-native-webview": "^13.13.4",
-    "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.1",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-firebase/analytics": "22.4.0",

--- a/packages/@divvi/mobile/package.json
+++ b/packages/@divvi/mobile/package.json
@@ -63,7 +63,7 @@
     "@divvi/cookies": "^6.2.3",
     "@divvi/react-native-fs": "^2.20.1",
     "@interaxyz/react-native-webview": "^13.13.4",
-    "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.1",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-firebase/analytics": "22.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3491,7 +3491,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@react-native-async-storage/async-storage@^2.1.2":
+"@react-native-async-storage/async-storage@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz#a3aa565253e46286655560172f4e366e8969f5ad"
   integrity sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==


### PR DESCRIPTION
### Description

Upgrades [`"@react-native-async-storage/async-storage": "^2.2.0"`](https://github.com/react-native-async-storage/async-storage/releases/tag/%40react-native-async-storage%2Fasync-storage%402.2.0)

### Test plan

- [ ] Tested in CI

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
