### PR TITLE
fix(keychain): use appropriate access control

### DIFF
--- a/packages/@divvi/mobile/src/pincode/authentication.test.ts
+++ b/packages/@divvi/mobile/src/pincode/authentication.test.ts
@@ -180,6 +180,7 @@ describe(getPincode, () => {
         title: 'unlockWithBiometryPrompt',
       },
       service: 'PIN',
+      accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
     })
   })
   it('logs an error if biometry fails, and requests pincode input', async () => {
@@ -198,6 +199,7 @@ describe(getPincode, () => {
         title: 'unlockWithBiometryPrompt',
       },
       service: 'PIN',
+      accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
     })
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       'storage/keychain',
@@ -224,6 +226,7 @@ describe(getPincode, () => {
         title: 'unlockWithBiometryPrompt',
       },
       service: 'PIN',
+      accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
     })
     expect(loggerErrorSpy).not.toHaveBeenCalled()
     expectPincodeEntered()

--- a/packages/@divvi/mobile/src/pincode/authentication.ts
+++ b/packages/@divvi/mobile/src/pincode/authentication.ts
@@ -273,6 +273,7 @@ export async function getPincodeWithBiometry() {
       authenticationPrompt: {
         title: i18n.t('unlockWithBiometryPrompt') ?? undefined,
       },
+      accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
     })
     if (retrievedPin) {
       AppAnalytics.track(AuthenticationEvents.get_pincode_with_biometry_complete)


### PR DESCRIPTION
### Description

Uses `ACCESS_CONTROL.BIOMETRY_CURRENT_SET` when retrieving from the keychain via `getPincodeWithBiometry`. This prevents the FaceID option from being served on Android, which fails and falls back to PIN.

### Test plan

- [x] Tested locally on Android
- [x] Tested locally on iOS

### Related issues

- N/A

### Backwards compatibility

Yes

### Network scalability

Yes
