### PR TITLE
fix(deps): use @divvi/react-native-keychain@10.0.0-divvi.1

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -23,7 +23,7 @@
     "@divvi/cookies": "^6.2.3",
     "@divvi/mobile": "*",
     "@divvi/react-native-fs": "^2.20.1",
-    "@divvi/react-native-keychain": "^10.0.0",
+    "@divvi/react-native-keychain": "^10.0.0-divvi.1",
     "@interaxyz/react-native-webview": "^13.13.4",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "resolutions": {
     "@divvi/cookies": "^6.2.3",
     "@divvi/react-native-fs": "^2.20.1",
-    "@divvi/react-native-keychain": "^10.0.0",
+    "@divvi/react-native-keychain": "^10.0.0-divvi.1",
     "@interaxyz/react-native-webview": "^13.13.4",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.3",

--- a/packages/@divvi/mobile/package.json
+++ b/packages/@divvi/mobile/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "@divvi/cookies": "^6.2.3",
     "@divvi/react-native-fs": "^2.20.1",
-    "@divvi/react-native-keychain": "^10.0.0",
+    "@divvi/react-native-keychain": "^10.0.0-divvi.1",
     "@interaxyz/react-native-webview": "^13.13.4",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.3",

--- a/packages/@divvi/mobile/src/account/saga.test.ts
+++ b/packages/@divvi/mobile/src/account/saga.test.ts
@@ -5,7 +5,6 @@ import * as matchers from 'redux-saga-test-plan/matchers'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { call, select } from 'redux-saga/effects'
 import {
-  clearStoredItemsSaga,
   generateSignedMessage,
   handleUpdateAccountRegistration,
   initializeAccountSaga,
@@ -18,7 +17,6 @@ import { Actions as AccountActions, phoneNumberVerificationCompleted } from 'src
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { retrieveSignedMessage, storeSignedMessage } from 'src/pincode/authentication'
-import { clearStoredItems } from 'src/storage/keychain'
 import Logger from 'src/utils/Logger'
 import { ViemKeychainAccount } from 'src/viem/keychainAccountToAccount'
 import { getKeychainAccounts } from 'src/web3/contracts'
@@ -207,33 +205,5 @@ describe('initializeAccount', () => {
       .run()
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('clearStoredItemsSaga', () => {
-  it('should call clearStoredItems and track analytics event', async () => {
-    const mockStaleItems = ['item1', 'item2']
-    await expectSaga(clearStoredItemsSaga)
-      .provide([[call(clearStoredItems), mockStaleItems]])
-      .call(clearStoredItems)
-      .call([AppAnalytics, 'track'], OnboardingEvents.stale_keychain_items_cleared, {
-        staleItems: mockStaleItems,
-        staleItemsCount: mockStaleItems.length,
-      })
-      .run()
-  })
-
-  it('should log error if clearStoredItems fails', async () => {
-    const error = new Error('Failed to clear items')
-    await expectSaga(clearStoredItemsSaga)
-      .provide([[call(clearStoredItems), throwError(error)]])
-      .call(clearStoredItems)
-      .run()
-
-    expect(loggerErrorSpy).toHaveBeenCalledWith(
-      'account/saga@clearKeychainItems',
-      'Failed to clear keychain items',
-      error
-    )
   })
 })

--- a/packages/@divvi/mobile/src/analytics/Events.tsx
+++ b/packages/@divvi/mobile/src/analytics/Events.tsx
@@ -203,8 +203,6 @@ export enum OnboardingEvents {
 
   link_phone_number = 'link_phone_number',
   link_phone_number_later = 'link_phone_number_later',
-
-  stale_keychain_items_cleared = 'stale_keychain_items_cleared',
 }
 
 // Events emitted in the CPV flow

--- a/packages/@divvi/mobile/src/analytics/Properties.tsx
+++ b/packages/@divvi/mobile/src/analytics/Properties.tsx
@@ -406,10 +406,6 @@ interface OnboardingEventsProperties {
   [OnboardingEvents.protect_wallet_complete]: undefined
   [OnboardingEvents.link_phone_number]: undefined
   [OnboardingEvents.link_phone_number_later]: undefined
-  [OnboardingEvents.stale_keychain_items_cleared]: {
-    staleItems: string[]
-    staleItemsCount: number
-  }
 }
 
 interface PhoneVerificationEventsProperties {

--- a/packages/@divvi/mobile/src/analytics/docs.ts
+++ b/packages/@divvi/mobile/src/analytics/docs.ts
@@ -215,7 +215,6 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [OnboardingEvents.protect_wallet_complete]: ``,
   [OnboardingEvents.link_phone_number]: `User chooses to link phone number for CPV after recovery flow`,
   [OnboardingEvents.link_phone_number_later]: `User chooses not to link phone number for CPV after recovery flow`,
-  [OnboardingEvents.stale_keychain_items_cleared]: `Stale keychain items where found during onboarding and cleared`,
 
   // Events emitted in the CPV flow
   [PhoneVerificationEvents.phone_verification_skip_confirm]: `when skip is confirmed from the dialog in the phone number input screen`,
@@ -669,4 +668,5 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   // [JumpstartEvents.jumpstart_add_assets_show_actions]: 'When user taps the CTA to show ways to add assets',
   // [JumpstartEvents.jumpstart_add_assets_action_press]: 'When user selects an add assets action from the available options',
   // [JumpstartEvents.jumpstart_intro_seen]: `when jumpstart intro is seen by the user`,
+  // [OnboardingEvents.stale_keychain_items_cleared]: `Stale keychain items where found during onboarding and cleared`,
 }

--- a/packages/@divvi/mobile/src/storage/keychain.tsx
+++ b/packages/@divvi/mobile/src/storage/keychain.tsx
@@ -90,17 +90,3 @@ export async function listStoredItems() {
     throw error
   }
 }
-
-export async function clearStoredItems(): Promise<string[]> {
-  const items = await listStoredItems()
-  const promises = items.map((item) => removeStoredItem(item))
-  const results = await Promise.allSettled(promises)
-
-  results.forEach((result, index) => {
-    if (result.status === 'rejected') {
-      Logger.error(TAG, `Failed to remove stored item: ${items[index]}`, result.reason)
-    }
-  })
-
-  return items
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,10 +1110,10 @@
     base-64 "^0.1.0"
     utf8 "^3.0.0"
 
-"@divvi/react-native-keychain@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@divvi/react-native-keychain/-/react-native-keychain-10.0.0.tgz#607e6a6170b1a73740c18d8dc66b45293f28dcd0"
-  integrity sha512-S6+NgTO8d9P6jEPo2T2V9N1iX98XOBG9+gznOuexuvIcGZ4j1CsaM1s8Gede0CqTTHnBgkox12Z2d0/JCm7EoA==
+"@divvi/react-native-keychain@^10.0.0-divvi.1":
+  version "10.0.0-divvi.1"
+  resolved "https://registry.yarnpkg.com/@divvi/react-native-keychain/-/react-native-keychain-10.0.0-divvi.1.tgz#33c0464880d248af0bc69f44b0f2e6f95b032ff3"
+  integrity sha512-3UuNLwnsNuDUm5N5318a/B1MBpyCdoJl9ZR7ehqEQukGRMvGvd3jAjisWSF1H6pnc96ly5fC/H0Z7gbjIdudlg==
 
 "@divvi/referral-sdk@^2.2.0":
   version "2.2.0"


### PR DESCRIPTION
### Description

Use latest version of `@divvi/react-native-keychain` which contains https://github.com/oblador/react-native-keychain/pull/773

It's published from https://github.com/mobilestack-xyz/react-native-keychain/commits/divvi-fork/

Note: I've chosen this versioning scheme to denote it's react-native-keychain version 10.0.0 + divvi changes

### Test plan

- See https://github.com/oblador/react-native-keychain/pull/773

### Related issues

- Part of ENG-636

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
