### PR TITLE
fix: revert divvi-xyz/divvi-mobile#208

### DIFF
--- a/packages/@divvi/mobile/src/account/saga.test.ts
+++ b/packages/@divvi/mobile/src/account/saga.test.ts
@@ -5,7 +5,6 @@ import * as matchers from 'redux-saga-test-plan/matchers'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { call, select } from 'redux-saga/effects'
 import {
-  clearStoredItemsSaga,
   generateSignedMessage,
   handleUpdateAccountRegistration,
   initializeAccountSaga,
@@ -18,7 +17,6 @@ import { Actions as AccountActions, phoneNumberVerificationCompleted } from 'src
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { retrieveSignedMessage, storeSignedMessage } from 'src/pincode/authentication'
-import { clearStoredItems } from 'src/storage/keychain'
 import Logger from 'src/utils/Logger'
 import { ViemKeychainAccount } from 'src/viem/keychainAccountToAccount'
 import { getKeychainAccounts } from 'src/web3/contracts'
@@ -207,33 +205,5 @@ describe('initializeAccount', () => {
       .run()
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('clearStoredItemsSaga', () => {
-  it('should call clearStoredItems and track analytics event', async () => {
-    const mockStaleItems = ['item1', 'item2']
-    await expectSaga(clearStoredItemsSaga)
-      .provide([[call(clearStoredItems), mockStaleItems]])
-      .call(clearStoredItems)
-      .call([AppAnalytics, 'track'], OnboardingEvents.stale_keychain_items_cleared, {
-        staleItems: mockStaleItems,
-        staleItemsCount: mockStaleItems.length,
-      })
-      .run()
-  })
-
-  it('should log error if clearStoredItems fails', async () => {
-    const error = new Error('Failed to clear items')
-    await expectSaga(clearStoredItemsSaga)
-      .provide([[call(clearStoredItems), throwError(error)]])
-      .call(clearStoredItems)
-      .run()
-
-    expect(loggerErrorSpy).toHaveBeenCalledWith(
-      'account/saga@clearKeychainItems',
-      'Failed to clear keychain items',
-      error
-    )
   })
 })

--- a/packages/@divvi/mobile/src/analytics/Events.tsx
+++ b/packages/@divvi/mobile/src/analytics/Events.tsx
@@ -203,8 +203,6 @@ export enum OnboardingEvents {
 
   link_phone_number = 'link_phone_number',
   link_phone_number_later = 'link_phone_number_later',
-
-  stale_keychain_items_cleared = 'stale_keychain_items_cleared',
 }
 
 // Events emitted in the CPV flow

--- a/packages/@divvi/mobile/src/analytics/Properties.tsx
+++ b/packages/@divvi/mobile/src/analytics/Properties.tsx
@@ -406,10 +406,6 @@ interface OnboardingEventsProperties {
   [OnboardingEvents.protect_wallet_complete]: undefined
   [OnboardingEvents.link_phone_number]: undefined
   [OnboardingEvents.link_phone_number_later]: undefined
-  [OnboardingEvents.stale_keychain_items_cleared]: {
-    staleItems: string[]
-    staleItemsCount: number
-  }
 }
 
 interface PhoneVerificationEventsProperties {

--- a/packages/@divvi/mobile/src/analytics/docs.ts
+++ b/packages/@divvi/mobile/src/analytics/docs.ts
@@ -215,7 +215,6 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [OnboardingEvents.protect_wallet_complete]: ``,
   [OnboardingEvents.link_phone_number]: `User chooses to link phone number for CPV after recovery flow`,
   [OnboardingEvents.link_phone_number_later]: `User chooses not to link phone number for CPV after recovery flow`,
-  [OnboardingEvents.stale_keychain_items_cleared]: `Stale keychain items where found during onboarding and cleared`,
 
   // Events emitted in the CPV flow
   [PhoneVerificationEvents.phone_verification_skip_confirm]: `when skip is confirmed from the dialog in the phone number input screen`,
@@ -669,4 +668,5 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   // [JumpstartEvents.jumpstart_add_assets_show_actions]: 'When user taps the CTA to show ways to add assets',
   // [JumpstartEvents.jumpstart_add_assets_action_press]: 'When user selects an add assets action from the available options',
   // [JumpstartEvents.jumpstart_intro_seen]: `when jumpstart intro is seen by the user`,
+  // [OnboardingEvents.stale_keychain_items_cleared]: `Stale keychain items where found during onboarding and cleared`,
 }

--- a/packages/@divvi/mobile/src/storage/keychain.tsx
+++ b/packages/@divvi/mobile/src/storage/keychain.tsx
@@ -90,17 +90,3 @@ export async function listStoredItems() {
     throw error
   }
 }
-
-export async function clearStoredItems(): Promise<string[]> {
-  const items = await listStoredItems()
-  const promises = items.map((item) => removeStoredItem(item))
-  const results = await Promise.allSettled(promises)
-
-  results.forEach((result, index) => {
-    if (result.status === 'rejected') {
-      Logger.error(TAG, `Failed to remove stored item: ${items[index]}`, result.reason)
-    }
-  })
-
-  return items
-}


### PR DESCRIPTION
### Description

https://github.com/divvi-xyz/divvi-mobile/pull/258 fixes the lower level issue that was partially mitigated by https://github.com/divvi-xyz/divvi-mobile/pull/208

I decided to revert it, because it's not necessary anymore and also because it wipes everything in the keychain, even values that are set by other libs (e.g. firebase items), which may or may not cause issues.

### Test plan

- Manually tested restoring an existing react-native-keychain datastore after wiping the Keystore, still allows to restore or create a new account. See https://github.com/divvi-xyz/divvi-mobile/pull/208 reproduction.

### Related issues

- Part of ENG-636

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
