### PR TITLE
wallet_getCapabilities

### DIFF
--- a/packages/@divvi/mobile/locales/base/translation.json
+++ b/packages/@divvi/mobile/locales/base/translation.json
@@ -1164,6 +1164,8 @@
     "decryptPayloadTitle": "Decrypt with wallet",
     "decryptPayload": "{{dappName}} would like to decrypt a data payload.",
     "computeSharedSecret": "{{dappName}} would like to generate secrets.",
+    "getCapabilitiesTitle": "Wallet capabilities",
+    "getCapabilities": "{{dappName}} would like to read the capabilities of your wallet.",
     "transactionDataCopied": "Transaction data copied",
     "estimatedNetworkFee": "Estimated {{networkName}} Network Fee",
     "networksList": "Networks",

--- a/packages/@divvi/mobile/src/walletConnect/capabilities.ts
+++ b/packages/@divvi/mobile/src/walletConnect/capabilities.ts
@@ -1,0 +1,76 @@
+import { NetworkId } from 'src/transactions/types'
+import networkConfig, { networkIdToNetwork, viemChainIdToNetworkId } from 'src/web3/networkConfig'
+import { getSupportedNetworkIds } from 'src/web3/utils'
+import { hexToNumber, isHex, toHex } from 'viem'
+
+type AtomicCapability = {
+  status: 'supported' | 'ready' | 'unsupported'
+}
+
+type PaymasterServiceCapability = {
+  supported: boolean
+}
+
+type Capabilities = {
+  atomic: AtomicCapability
+  paymasterService: PaymasterServiceCapability
+}
+
+type CapabilitiesByNetworkId = Record<keyof typeof NetworkId, Capabilities>
+
+const defaultCapabilities: Capabilities = {
+  atomic: { status: 'unsupported' },
+  paymasterService: { supported: false },
+}
+
+export const capabilitiesByNetworkId: CapabilitiesByNetworkId = {
+  [NetworkId['celo-alfajores']]: defaultCapabilities,
+  [NetworkId['celo-mainnet']]: defaultCapabilities,
+  [NetworkId['ethereum-mainnet']]: defaultCapabilities,
+  [NetworkId['ethereum-sepolia']]: defaultCapabilities,
+  [NetworkId['arbitrum-one']]: defaultCapabilities,
+  [NetworkId['arbitrum-sepolia']]: defaultCapabilities,
+  [NetworkId['op-mainnet']]: defaultCapabilities,
+  [NetworkId['op-sepolia']]: defaultCapabilities,
+  [NetworkId['polygon-pos-mainnet']]: defaultCapabilities,
+  [NetworkId['polygon-pos-amoy']]: defaultCapabilities,
+  [NetworkId['base-mainnet']]: defaultCapabilities,
+  [NetworkId['base-sepolia']]: defaultCapabilities,
+}
+
+export function getWalletCapabilities(requestedChainIds?: unknown): Record<string, Capabilities> {
+  const supportedNetworkIds = getSupportedNetworkIds()
+
+  let targetNetworkIds: NetworkId[] = []
+
+  if (!requestedChainIds) {
+    targetNetworkIds = supportedNetworkIds
+  } else {
+    if (!Array.isArray(requestedChainIds)) {
+      throw new Error('requested chainIds must be provided as an array')
+    }
+
+    if (requestedChainIds.length === 0) {
+      throw new Error('requested chainIds array must not be empty')
+    }
+
+    if (requestedChainIds.some((chainId) => !isHex(chainId))) {
+      throw new Error('requested chainIds must be expressed as hex numbers')
+    }
+
+    const requestedNetworkIds = new Set(
+      requestedChainIds.map((chainId) => viemChainIdToNetworkId[hexToNumber(chainId)])
+    )
+
+    targetNetworkIds = supportedNetworkIds.filter((networkId) => requestedNetworkIds.has(networkId))
+  }
+
+  const result: Record<string, Capabilities> = {}
+
+  for (const networkId of targetNetworkIds) {
+    const chainId = networkConfig.viemChain[networkIdToNetwork[networkId]].id
+    result[toHex(chainId)] = capabilitiesByNetworkId[networkId]
+  }
+
+  return result
+}

--- a/packages/@divvi/mobile/src/walletConnect/constants.ts
+++ b/packages/@divvi/mobile/src/walletConnect/constants.ts
@@ -7,6 +7,7 @@ export enum SupportedActions {
   eth_signTypedData_v4 = 'eth_signTypedData_v4',
   eth_sign = 'eth_sign',
   personal_sign = 'personal_sign',
+  wallet_getCapabilities = 'wallet_getCapabilities',
 }
 
 export enum SupportedEvents {
@@ -65,6 +66,11 @@ export function getDisplayTextFromAction(
       title: t('walletConnectRequest.signPayloadTitle'),
       action: t('allow'),
     },
+    [SupportedActions.wallet_getCapabilities]: {
+      description: t('walletConnectRequest.getCapabilities', { dappName }),
+      title: t('walletConnectRequest.getCapabilitiesTitle'),
+      action: t('allow'),
+    },
   }
 
   const translations = actionTranslations[action]
@@ -75,4 +81,7 @@ export function getDisplayTextFromAction(
   return translations
 }
 
-export const chainAgnosticActions: string[] = [SupportedActions.personal_sign]
+export const chainAgnosticActions: string[] = [
+  SupportedActions.personal_sign,
+  SupportedActions.wallet_getCapabilities,
+]

--- a/packages/@divvi/mobile/src/walletConnect/request.test.ts
+++ b/packages/@divvi/mobile/src/walletConnect/request.test.ts
@@ -11,6 +11,7 @@ import { getViemWallet } from 'src/web3/contracts'
 import { unlockAccount } from 'src/web3/saga'
 import { createMockStore } from 'test/utils'
 import {
+  mockAddress,
   mockCeloAddress,
   mockCeloTokenId,
   mockCeurAddress,
@@ -32,6 +33,11 @@ jest.mock('src/web3/networkConfig', () => {
     },
   }
 })
+
+jest.mock('src/web3/utils', () => ({
+  ...jest.requireActual('src/web3/utils'),
+  getSupportedNetworkIds: () => ['ethereum-sepolia', 'arbitrum-sepolia'],
+}))
 
 const signTransactionRequest = {
   request: {
@@ -207,5 +213,81 @@ describe(handleRequest, () => {
           .run()
     ).rejects.toThrow('unsupported network')
     expect(viemWallet.sendTransaction).not.toHaveBeenCalled()
+  })
+
+  describe('wallet_getCapabilities', () => {
+    it('returns all supported chains capabilities when client did not provide any hex chain ids', async () => {
+      const request = {
+        request: {
+          method: SupportedActions.wallet_getCapabilities,
+          params: [mockAddress],
+        },
+        chainId: 'eip155:11155111',
+      }
+      const expectedResult = {
+        '0xaa36a7': { atomic: { status: 'unsupported' }, paymasterService: { supported: false } },
+        '0x66eee': { atomic: { status: 'unsupported' }, paymasterService: { supported: false } },
+      }
+
+      await expectSaga(handleRequest, request).withState(state).returns(expectedResult).run()
+    })
+
+    it('handles hex chain ids in wallet_getCapabilities when client provided some hex chain ids', async () => {
+      const request = {
+        request: {
+          method: SupportedActions.wallet_getCapabilities,
+          params: [mockAddress, ['0xaa36a7', '0x66eee']], // ethereum-sepolia and arbitrum-sepolia
+        },
+        chainId: 'eip155:11155111',
+      }
+      const expectedResult = {
+        '0xaa36a7': { atomic: { status: 'unsupported' }, paymasterService: { supported: false } },
+        '0x66eee': { atomic: { status: 'unsupported' }, paymasterService: { supported: false } },
+      }
+
+      await expectSaga(handleRequest, request).withState(state).returns(expectedResult).run()
+    })
+
+    it('throws error when invalid chain id is provided', async () => {
+      const request = {
+        request: {
+          method: SupportedActions.wallet_getCapabilities,
+          params: [mockAddress, ['0xaa36a7', 'invalid_chain_id', '0x66eee']],
+        },
+        chainId: 'eip155:11155111',
+      }
+
+      await expect(
+        async () => await expectSaga(handleRequest, request).withState(state).run()
+      ).rejects.toThrow('requested chainIds must be expressed as hex numbers')
+    })
+
+    it('throws error when empty chain ids array is provided', async () => {
+      const request = {
+        request: {
+          method: SupportedActions.wallet_getCapabilities,
+          params: [mockAddress, []],
+        },
+        chainId: 'eip155:11155111',
+      }
+
+      await expect(
+        async () => await expectSaga(handleRequest, request).withState(state).run()
+      ).rejects.toThrow('requested chainIds array must not be empty')
+    })
+
+    it('throws error when non-array parameter is provided instead of chain ids array', async () => {
+      const request = {
+        request: {
+          method: SupportedActions.wallet_getCapabilities,
+          params: [mockAddress, 'not_an_array'],
+        },
+        chainId: 'eip155:11155111',
+      }
+
+      await expect(
+        async () => await expectSaga(handleRequest, request).withState(state).run()
+      ).rejects.toThrow('requested chainIds must be provided as an array')
+    })
   })
 })

--- a/packages/@divvi/mobile/src/walletConnect/request.ts
+++ b/packages/@divvi/mobile/src/walletConnect/request.ts
@@ -8,6 +8,7 @@ import {
   SerializableTransactionRequest,
   getPreparedTransaction,
 } from 'src/viem/preparedTransactionSerialization'
+import { getWalletCapabilities } from 'src/walletConnect/capabilities'
 import { SupportedActions, chainAgnosticActions } from 'src/walletConnect/constants'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig, {
@@ -85,6 +86,10 @@ export function* handleRequest(
     case SupportedActions.eth_sign: {
       const data = { message: { raw: params[1] } } as SignMessageParameters
       return (yield* call([wallet, 'signMessage'], data)) as string
+    }
+    case SupportedActions.wallet_getCapabilities: {
+      const [, hexNetworkIds] = params
+      return yield* call(getWalletCapabilities, hexNetworkIds)
     }
     default:
       throw new Error('unsupported RPC method')

--- a/packages/@divvi/mobile/src/web3/networkConfig.ts
+++ b/packages/@divvi/mobile/src/web3/networkConfig.ts
@@ -596,6 +596,21 @@ for (const [walletConnectChainId, networkId] of Object.entries(walletConnectChai
   walletConnectChainIdToNetwork[walletConnectChainId] = networkIdToNetwork[networkId]
 }
 
+export const viemChainIdToNetworkId: Record<number, NetworkId> = {
+  [celoAlfajores.id]: NetworkId['celo-alfajores'],
+  [celo.id]: NetworkId['celo-mainnet'],
+  [ethereum.id]: NetworkId['ethereum-mainnet'],
+  [ethereumSepolia.id]: NetworkId['ethereum-sepolia'],
+  [arbitrum.id]: NetworkId['arbitrum-one'],
+  [arbitrumSepolia.id]: NetworkId['arbitrum-sepolia'],
+  [optimism.id]: NetworkId['op-mainnet'],
+  [optimismSepolia.id]: NetworkId['op-sepolia'],
+  [polygon.id]: NetworkId['polygon-pos-mainnet'],
+  [polygonAmoy.id]: NetworkId['polygon-pos-amoy'],
+  [base.id]: NetworkId['base-mainnet'],
+  [baseSepolia.id]: NetworkId['base-sepolia'],
+}
+
 Logger.info('Connecting to testnet: ', DEFAULT_TESTNET)
 
 export default networkConfigs[DEFAULT_TESTNET]


### PR DESCRIPTION
### Description

Implement support for `wallet_getCapabilities` request (EIP-5792) through WalletConnect.

EIP-5792:
* https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities
* https://www.eip5792.xyz/reference/getCapabilities

### Note on mobile UX

Whenever a dapp sends a WalletConnect request, the user must open their wallet app to respond. The mobile app can’t process the request quietly in the background. This means the user has to do an extra app switch, which adds friction to the experience (see video below).

For instance, when using `useCapabilities` together with a WalletConnect provider, as soon as the connection succeeds, `useCapabilities` will automatically request the wallet’s capabilities. That triggers another deep link into the wallet without any explanation to the user. From their perspective, it might feel like the app is bouncing them around for no clear reason, even like a bug.

To mitigate that, it is probably better to give users context up front. Instead of relying on the automatic call, builders might consider prompting users directly to share their wallet capabilities before sending the request. This way, they will know what’s happening and why.

https://github.com/user-attachments/assets/473a6915-fc72-450c-8843-593a501718a5

### Test plan

* Tested manually using 
* Updated unit test

### Related issues

- Part of ENG-644

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
