### PR TITLE
chore(walletconnect): refactor to support many tx

### DIFF
--- a/packages/@divvi/mobile/src/walletConnect/actions.ts
+++ b/packages/@divvi/mobile/src/walletConnect/actions.ts
@@ -72,7 +72,7 @@ export interface ShowRequestDetails {
 export interface AcceptRequest {
   type: Actions.ACCEPT_REQUEST
   request: WalletKitTypes.EventArguments['session_request']
-  preparedTransaction?: SerializableTransactionRequest
+  preparedTransactions?: SerializableTransactionRequest[]
 }
 export interface DenyRequest {
   type: Actions.DENY_REQUEST
@@ -179,11 +179,11 @@ export const showRequestDetails = (
 
 export const acceptRequest = (
   request: WalletKitTypes.EventArguments['session_request'],
-  preparedTransaction?: SerializableTransactionRequest
+  preparedTransactions?: SerializableTransactionRequest[]
 ): AcceptRequest => ({
   type: Actions.ACCEPT_REQUEST,
   request,
-  preparedTransaction,
+  preparedTransactions,
 })
 
 export const denyRequest = (

--- a/packages/@divvi/mobile/src/walletConnect/request.ts
+++ b/packages/@divvi/mobile/src/walletConnect/request.ts
@@ -30,7 +30,7 @@ export function* handleRequest(
     request: { method, params },
     chainId,
   }: WalletKitTypes.EventArguments['session_request']['params'],
-  serializableTransactionRequest?: SerializableTransactionRequest
+  serializableTransactionRequests?: SerializableTransactionRequest[]
 ) {
   // since the chainId comes from the dapp, we cannot be sure that it is a
   // supported chain id. for transactions that are sent to the blockchain, it is
@@ -60,10 +60,10 @@ export function* handleRequest(
 
   switch (method) {
     case SupportedActions.eth_signTransaction: {
-      if (!serializableTransactionRequest) {
-        throw new Error('preparedTransaction is required when using viem')
+      if (!serializableTransactionRequests || serializableTransactionRequests.length === 0) {
+        throw new Error('preparedTransactions is required when using viem')
       }
-      const tx = getPreparedTransaction(serializableTransactionRequest)
+      const tx = getPreparedTransaction(serializableTransactionRequests[0])
       Logger.debug(TAG + '@handleRequest', 'Signing transaction', tx)
       return yield* call(
         [wallet, 'signTransaction'],
@@ -72,10 +72,10 @@ export function* handleRequest(
       )
     }
     case SupportedActions.eth_sendTransaction: {
-      if (!serializableTransactionRequest) {
+      if (!serializableTransactionRequests || serializableTransactionRequests.length === 0) {
         throw new Error('preparedTransaction is required when using viem')
       }
-      const tx = getPreparedTransaction(serializableTransactionRequest)
+      const tx = getPreparedTransaction(serializableTransactionRequests[0])
       Logger.debug(TAG + '@handleRequest', 'Sending transaction', tx)
       const hash = yield* call(
         [wallet, 'sendTransaction'],

--- a/packages/@divvi/mobile/src/walletConnect/saga.test.ts
+++ b/packages/@divvi/mobile/src/walletConnect/saga.test.ts
@@ -33,7 +33,7 @@ import {
   handlePendingState,
   initialiseWalletConnect,
   initialiseWalletConnectV2,
-  normalizeTransaction,
+  normalizeTransactions,
   walletConnectSaga,
 } from 'src/walletConnect/saga'
 import { WalletConnectRequestType } from 'src/walletConnect/types'
@@ -805,10 +805,10 @@ describe('normalizeTransaction', () => {
   }
 
   function callNormalizeTransaction(transaction: any, network: Network) {
-    return expectSaga(normalizeTransaction, transaction, network)
+    return expectSaga(normalizeTransactions, [transaction], network)
       .provide(createDefaultProviders(network))
       .run()
-      .then((result) => result.returnValue)
+      .then((result) => result.returnValue[0])
   }
 
   it('ensures `gasLimit` value is removed and used as `gas` instead', async () => {

--- a/packages/@divvi/mobile/src/walletConnect/screens/ActionRequest.tsx
+++ b/packages/@divvi/mobile/src/walletConnect/screens/ActionRequest.tsx
@@ -29,8 +29,8 @@ export interface ActionRequestProps {
   supportedChains: string[]
   hasInsufficientGasFunds: boolean
   feeCurrenciesSymbols: string[]
-  preparedTransaction?: SerializableTransactionRequest
-  prepareTransactionErrorMessage?: string
+  preparedTransactions: SerializableTransactionRequest[]
+  prepareTransactionsErrorMessage?: string
 }
 
 function ActionRequest({
@@ -38,8 +38,8 @@ function ActionRequest({
   supportedChains,
   hasInsufficientGasFunds,
   feeCurrenciesSymbols,
-  preparedTransaction,
-  prepareTransactionErrorMessage,
+  preparedTransactions,
+  prepareTransactionsErrorMessage,
 }: ActionRequestProps) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -129,7 +129,7 @@ function ActionRequest({
   }
 
   if (
-    !preparedTransaction &&
+    !preparedTransactions &&
     (method === InteractiveActions.eth_signTransaction ||
       method === InteractiveActions.eth_sendTransaction)
   ) {
@@ -146,13 +146,13 @@ function ActionRequest({
         <ActionRequestPayload
           session={activeSession}
           request={pendingAction}
-          preparedTransaction={preparedTransaction}
+          preparedTransactions={preparedTransactions}
         />
         <InLineNotification
           variant={NotificationVariant.Warning}
           title={t('walletConnectRequest.failedToPrepareTransaction.title')}
           description={t('walletConnectRequest.failedToPrepareTransaction.description', {
-            errorMessage: prepareTransactionErrorMessage,
+            errorMessage: prepareTransactionsErrorMessage,
           })}
           style={styles.warning}
         />
@@ -164,7 +164,7 @@ function ActionRequest({
     <RequestContent
       type="confirm"
       buttonText={action}
-      onAccept={() => dispatch(acceptRequest(pendingAction, preparedTransaction))}
+      onAccept={() => dispatch(acceptRequest(pendingAction, preparedTransactions))}
       onDeny={() => {
         dispatch(denyRequest(pendingAction, getSdkError('USER_REJECTED')))
       }}
@@ -177,13 +177,13 @@ function ActionRequest({
       <ActionRequestPayload
         session={activeSession}
         request={pendingAction}
-        preparedTransaction={preparedTransaction}
+        preparedTransactions={preparedTransactions}
       />
-      {preparedTransaction && (
+      {preparedTransactions && (
         <EstimatedNetworkFee
           isLoading={false}
           networkId={networkId}
-          transactions={[preparedTransaction]}
+          transactions={preparedTransactions}
         />
       )}
       <DappsDisclaimer isDappListed={isDappListed} />

--- a/packages/@divvi/mobile/src/walletConnect/screens/ActionRequestPayload.tsx
+++ b/packages/@divvi/mobile/src/walletConnect/screens/ActionRequestPayload.tsx
@@ -18,7 +18,7 @@ import { SupportedActions } from 'src/walletConnect/constants'
 type Props = {
   session: SessionTypes.Struct
   request: WalletKitTypes.EventArguments['session_request']
-  preparedTransaction?: SerializableTransactionRequest
+  preparedTransactions?: SerializableTransactionRequest[]
 }
 
 function ActionRequestPayload(props: Props) {
@@ -31,7 +31,7 @@ function ActionRequestPayload(props: Props) {
     () =>
       method === SupportedActions.eth_signTransaction ||
       method === SupportedActions.eth_sendTransaction
-        ? JSON.stringify(props.preparedTransaction ?? params)
+        ? JSON.stringify(props.preparedTransactions?.[0] ?? params)
         : method === SupportedActions.eth_signTypedData ||
             method === SupportedActions.eth_signTypedData_v4
           ? JSON.stringify(params[1])
@@ -40,7 +40,7 @@ function ActionRequestPayload(props: Props) {
               params[0] ||
               t('action.emptyMessage')
             : null,
-    [method, params, props.preparedTransaction]
+    [method, params, props.preparedTransactions]
   )
 
   const handleTrackCopyRequestPayload = () => {


### PR DESCRIPTION
### Description

Refactor to handle multiple transactions (instead of a single one).

This change lays the groundwork for the upcoming `wallet_sendCalls` method implementation, where multiple transactions need to be handled when atomic execution is neither requested by the dapp nor supported by the wallet.

### Review notes

Better reviewed with collapsed whitespace.

### Test plan

CI

### Related issues

- Related to ENG-644

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
