### PR TITLE
fix(walletconnect): do not navigate to loader for non-interactive actions

### DIFF
--- a/packages/@divvi/mobile/src/walletConnect/saga.test.ts
+++ b/packages/@divvi/mobile/src/walletConnect/saga.test.ts
@@ -18,6 +18,7 @@ import { publicClient } from 'src/viem'
 import { prepareTransactions } from 'src/viem/prepareTransactions'
 import {
   Actions,
+  acceptRequest,
   acceptSession as acceptSessionAction,
   sessionProposal as sessionProposalAction,
 } from 'src/walletConnect/actions'
@@ -725,6 +726,29 @@ describe('showActionRequest', () => {
       preparedTransactions: undefined,
       prepareTransactionsErrorMessage: 'viem short message',
     })
+  })
+
+  it('accepts non-interactive requests immediately without navigation', async () => {
+    const nonInteractiveRequest: WalletKitTypes.EventArguments['session_request'] = {
+      ...actionRequest,
+      params: {
+        ...actionRequest.params,
+        request: {
+          method: 'wallet_getCapabilities',
+          params: [],
+        },
+      },
+    }
+
+    const state = createMockStore({}).getState()
+    await expectSaga(_showActionRequest, nonInteractiveRequest)
+      .withState(state)
+      .provide([[select(walletAddressSelector), mockAccount]])
+      .put(acceptRequest(nonInteractiveRequest))
+      .run()
+
+    // Should not navigate to any screen
+    expect(navigate).not.toHaveBeenCalled()
   })
 
   it('throws an error when client is missing', () => {

--- a/packages/@divvi/mobile/src/walletConnect/saga.ts
+++ b/packages/@divvi/mobile/src/walletConnect/saga.ts
@@ -504,18 +504,18 @@ function* showActionRequest(request: WalletKitTypes.EventArguments['session_requ
     return
   }
 
+  // If the action doesn't require user consent, accept it immediately
+  if (!isInteractiveAction(method)) {
+    yield* put(acceptRequest(request))
+    return
+  }
+
   // since there are some network requests needed to prepare the transactions,
   // add a loading state
   navigate(Screens.WalletConnectRequest, {
     type: WalletConnectRequestType.Loading,
     origin: WalletConnectPairingOrigin.Deeplink,
   })
-
-  // If the action doesn't require user consent, accept it immediately
-  if (!isInteractiveAction(method)) {
-    yield* put(acceptRequest(request))
-    return
-  }
 
   const supportedChains = yield* call(getSupportedChains)
 


### PR DESCRIPTION
### Description

When handling non-interactive actions (`wallet_getCapabilities` for now), there is no need to display a bottom sheet with a spinner, since there will be no follow-up bottom sheet.

### Test plan

* Added unit test

### Related issues

- Related to ENG-644

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
